### PR TITLE
Change Sys_SnapVector to `rint` the components for x64 linux/mingw.

### DIFF
--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -3457,9 +3457,9 @@ __asm {
 
 void Sys_SnapVector( vec3_t vec )
 {
-	vec[0] = round(vec[0]);
-	vec[1] = round(vec[1]);
-	vec[2] = round(vec[2]);
+	vec[0] = rint(vec[0]);
+	vec[1] = rint(vec[1]);
+	vec[2] = rint(vec[2]);
 }
 
 #else // id386


### PR DESCRIPTION
As far as I can tell, all the other platforms/engines round the vector
components to the nearest int (even). `round` doesn't do this,
regardless of the rounding mode that is set. `rint` on the other hand
does do this.