### PR TITLE
Add a `.mailmap` file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Eugene <tweels@gmail.com> <eugene@832414e2-6573-9c40-a513-caa1f8131539>
+Eugene <tweels@gmail.com>


### PR DESCRIPTION
This normalizes author information when using commands such as `git log` or `git shortlog`. [More information.](https://www.git-scm.com/docs/git-check-mailmap)

Pretty minor thing, but I guess it doesn't hurt to fix it :slightly_smiling_face: