### PR TITLE
enabled using libjpeg provided by the system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ USE_SDL          = 0
 USE_CURL         = 1
 USE_LOCAL_HEADERS= 0
 USE_VULKAN       = 0
+USE_SYSTEM_JPEG  = 0
 #USE_VULKAN_API   = 0
 
 USE_RENDERER_DLOPEN = 0
@@ -167,7 +168,9 @@ UDIR=$(MOUNT_DIR)/unix
 W32DIR=$(MOUNT_DIR)/win32
 BLIBDIR=$(MOUNT_DIR)/botlib
 UIDIR=$(MOUNT_DIR)/ui
-JPDIR=$(MOUNT_DIR)/jpeg-8c
+ifeq ($(USE_SYSTEM_JPEG),0)
+	JPDIR=$(MOUNT_DIR)/jpeg-8c
+endif
 LOKISETUPDIR=$(UDIR)/setup
 
 bin_path=$(shell which $(1) 2> /dev/null)
@@ -209,6 +212,10 @@ endif
 endif
 
 BASE_CFLAGS =
+
+ifeq ($(USE_SYSTEM_JPEG),1)
+  BASE_CFLAGS += -DUSE_SYSTEM_JPEG
+endif
 
 ifneq ($(HAVE_VM_COMPILED),true)
   BASE_CFLAGS += -DNO_VM_COMPILED
@@ -939,7 +946,11 @@ Q3OBJ = \
   $(B)/client/l_script.o \
   $(B)/client/l_struct.o
 
+ifeq ($(USE_SYSTEM_JPEG),0)
   Q3OBJ += $(JPGOBJ)
+else
+  CLIENT_LDFLAGS += -ljpeg
+endif
 
 ifeq ($(USE_RENDERER_DLOPEN),0)
 

--- a/code/client/cl_jpeg.c
+++ b/code/client/cl_jpeg.c
@@ -32,18 +32,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * You may also wish to include "jerror.h".
  */
 
-//#ifdef USE_INTERNAL_JPEG
-#  define JPEG_INTERNALS
-//#endif
-
-#include "../jpeg-8c/jpeglib.h"
-
-#ifndef USE_INTERNAL_JPEG
-#  if JPEG_LIB_VERSION < 80 && !defined(MEM_SRCDST_SUPPORTED)
-#    error Need system libjpeg >= 80 or jpeg_mem_ support
-#  endif
-#  endif
-
+#ifdef USE_SYSTEM_JPEG
+#	include <jpeglib.h>
+#	if JPEG_LIB_VERSION < 80 && !defined(MEM_SRCDST_SUPPORTED)
+#		error Need system libjpeg >= 80 or jpeg_mem_ support
+#	endif
+#else
+#	define JPEG_INTERNALS
+#	include "../jpeg-8c/jpeglib.h"
+#endif
 
 /* Catching errors, as done in libjpeg's example.c */
 typedef struct q_jpeg_error_mgr_s


### PR DESCRIPTION
Tested on Linux against libjpeg-turbo without jpeg8 support - works fine.

At first attempt, targa graphics and shaders would not load. `code/client/cl_jpeg.c` needs to include systemwide jpeg headers and pass a preprocessor check, so that libjpeg.so.6 won't throw a bunch of errors and warnings.

This scenario necessitates:
- the Makefile will not compile Quake's local copy of libjpeg if we choose to use system libjpeg (by default the Makefile prefers Quake's libjpeg so that nobody's workflow gets ruined)
- the Makefile will link quake3 client against system libjpeg when we want to use system jpeg
- the Makefile must add a declaration of USE_SYSTEM_JPEG to BASE_CFLAGS in order to trigger a preprocessor check that will let us enjoy targa and shader support in jpeg6 (default for Gentoo Linux' flavor of libjpeg-turbo, for whatever reason jpeg8 API is not available through USE flags, but that was not a significant problem)

The reason why I want to do this is because libjpeg-turbo is simply faster. We shouldn't tax Quake with the responsibility to optimize our libjpeg when there are already developers and package maintainers who do this.

More info:
1. https://libjpeg-turbo.org/About/Performance
2. https://libjpeg-turbo.org/About/SIMDCoverage