### PR TITLE
Fix build on Musl

### DIFF
--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -368,12 +368,14 @@ typedef	int	fixed16_t;
 #endif
 
 #ifdef __linux__
+#ifdef _GNU_SOURCE
 #if idx64
 // force version for better runtime compatibility
 __asm__(".symver logf,logf@GLIBC_2.2.5");
 __asm__(".symver powf,powf@GLIBC_2.2.5");
 __asm__(".symver expf,expf@GLIBC_2.2.5");
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+#endif
 #endif
 #endif
 

--- a/code/unix/unix_main.c
+++ b/code/unix/unix_main.c
@@ -38,9 +38,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <sys/mman.h>
 #include <errno.h>
 #include <libgen.h> // dirname
-#ifdef __linux__ // rb010123
-  #include <mntent.h>
-#endif
 
 #include <dlfcn.h>
 

--- a/code/unix/unix_main.c
+++ b/code/unix/unix_main.c
@@ -45,7 +45,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <dlfcn.h>
 
 #ifdef __linux__
+#ifdef _GNU_SOURCE
   #include <fpu_control.h> // bk001213 - force dumps on divide by zero
+#endif
 #endif
 
 #if defined(__sun)
@@ -779,6 +781,7 @@ void Sys_ConfigureFPU( void )  // bk001213 - divide by zero
 {
 #ifdef __linux__
 #ifdef __i386
+#ifdef _GNU_SOURCE
 #ifndef NDEBUG
 	// bk0101022 - enable FPE's in debug mode
 	static int fpu_word = _FPU_DEFAULT & ~(_FPU_MASK_ZM | _FPU_MASK_IM);
@@ -797,6 +800,7 @@ void Sys_ConfigureFPU( void )  // bk001213 - divide by zero
 	static int fpu_word = _FPU_DEFAULT;
 	_FPU_SETCW( fpu_word );
 #endif // NDEBUG
+#endif // _GNU_SOURCE
 #endif // __i386 
 #endif // __linux
 }


### PR DESCRIPTION
These patches fix the build on Linux when using [Musl](https://www.musl-libc.org/), whilst not removing any functionality on Glibc.