### PR TITLE
Fixed compilation (OpenGL2).

### DIFF
--- a/code/renderer2/tr_init.c
+++ b/code/renderer2/tr_init.c
@@ -214,6 +214,32 @@ int		max_polys;
 cvar_t	*r_maxpolyverts;
 int		max_polyverts;
 
+
+// for modular renderer
+#ifdef USE_RENDERER_DLOPEN
+void QDECL Com_Error( errorParm_t code, const char *fmt, ... )
+{
+	char buf[ 4096 ];
+	va_list	argptr;
+	va_start( argptr, fmt );
+	Q_vsnprintf( buf, sizeof( buf ), fmt, argptr );
+	va_end( argptr );
+	ri.Error( code, "%s", buf );
+}
+
+void QDECL Com_Printf( const char *fmt, ... )
+{
+	char buf[ MAXPRINTMSG ];
+	va_list	argptr;
+	va_start( argptr, fmt );
+	Q_vsnprintf( buf, sizeof( buf ), fmt, argptr );
+	va_end( argptr );
+
+	ri.Printf( PRINT_ALL, "%s", buf );
+}
+#endif
+
+
 /*
 ** InitOpenGL
 **


### PR DESCRIPTION
**Issue:**
Compiling current master with Cygwin on Windows fails because renderer 2 is missing two functions (Com_Error and Com_Printf). This happens with USE_RENDERER_DLOPEN = 1 (default).

**Changes:**
I copied those two functions from opengl renderer to the second render. This is an exact match of how it is done in the opengl renderer and in vulkan (tr_init.c), using #ifdef USE_RENDERER_DLOPEN.

**Result:**
All three renderers are compiling without errors on Cygwin/Windows 8.1 (64-bit).

**Note:**
This issue occurs even with USE_OPENGL2 = 0 (default) in the MAKEFILE. I don't want to change anything inside the MAKEFILE yet.
So nothing else will be affected with this PR.

