### PR TITLE
starthunk after hunk_setmark

### DIFF
--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -671,6 +671,15 @@ void SV_SpawnServer( const char *mapname, qboolean killBots ) {
 	Com_Printf ("-----------------------------------\n");
 
 	Sys_SetStatus( "Running map %s", mapname );
+  
+#ifndef DEDICATED
+  // Brian "megamind" Cullinan - if on the off chance there is a server error
+  //   preventing a connection for single player in SV_DirectConnect gamestate
+  //   will never be sent and won't restart client after shutdown above
+  if(!com_dedicated->integer) {
+    CL_StartHunkUsers();
+  }
+#endif
 }
 
 


### PR DESCRIPTION
Ran into this bug a couple of times, if a server error happens nothing is reported to the client game because client game isn't started until after gamestate is received. Gamestate won't be sent if the client is rejected in **single player mode**, some mods have error reporting on SV_DirectConnect() when they check for proper installation. Only affects single player, might be slower if there is a fs_game switch because it will need to shutdown UI again.

Take it or leave it. ¯\_(ツ)_/¯
