### PR TITLE
Increase MAX_SWAPCHAIN_IMAGES to 8

### DIFF
--- a/code/renderervk/vk.h
+++ b/code/renderervk/vk.h
@@ -3,7 +3,7 @@
 #include "../renderercommon/vulkan/vulkan.h"
 #include "tr_common.h"
 
-#define MAX_SWAPCHAIN_IMAGES 4
+#define MAX_SWAPCHAIN_IMAGES 8
 #define MIN_SWAPCHAIN_IMAGES_IMM 3
 #define MIN_SWAPCHAIN_IMAGES_FIFO 3
 #define MIN_SWAPCHAIN_IMAGES_MAILBOX 3


### PR DESCRIPTION
-- Fixes RADV segfault on 6800XT, using XWayland and SDL2 x11 backend. Without this patch, the use of env var `MESA_VK_WSI_PRESENT_MODE=fifo` was needed to prevent the segfault. The increase of 4->8 is taken from [vkQuake3's Vk renderer code](https://github.com/suijingfeng/vkQuake3/blob/master/code/renderer_vulkan/vk_instance.h#L132).
Original issue ticket was #119.