### PR TITLE
Mac M1 adjustments to CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif(UNIX)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES AMD|x86)
     set(VM_SRCS code/qcommon/vm_x86.c)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES aarch)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES aarch|arm64)
     set(VM_SRCS code/qcommon/vm_aarch64.c)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES arm)
     set(VM_SRCS code/qcommon/vm_armv7l.c)

--- a/cmake_modules/FindSDL2.cmake
+++ b/cmake_modules/FindSDL2.cmake
@@ -340,7 +340,7 @@ if(SDL2_FOUND)
             # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
             # For more details, please see above.
             set_target_properties(SDL2::Core PROPERTIES
-                    IMPORTED_LOCATION "${SDL2_LIBRARY}/SDL2"
+                    IMPORTED_LOCATION "${SDL2_LIBRARY}"
                     INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}")
         else()
             # For threads, as mentioned Apple doesn't need this.


### PR DESCRIPTION
Hello,

Here are 2 small changes I had to apply in order to make the project build on an M1.
Reasons for them are as follows:

* `CMAKE_SYSTEM_PROCESSOR` returned `arm64` for me, which resulted in using `vm_armv7l.c` file that broke linking as armv7 symbols were missing
* Setting `IMPORTED_LOCATION` to `${SDL2}/SDL` breaks linking as it resulted in an attempt to link a directory: 

```
make[2]: *** No rule to make target `/opt/homebrew/lib/libSDL2.dylib/SDL2', needed by `quake3e.app/Contents/MacOS/quake3e'. 
```

`IMPORTED_LOCATION` is supposed to point to a specific file, not a directory.

Regards,
Daniel