### PR TITLE
Allow 8× multisampling in traditional (non-framebuffer) MSAA

### DIFF
--- a/code/renderer2/tr_init.c
+++ b/code/renderer2/tr_init.c
@@ -1125,7 +1125,7 @@ void R_Register( void )
 	r_texturebits = ri.Cvar_Get( "r_texturebits", "0", CVAR_ARCHIVE | CVAR_LATCH );
 	r_stencilbits = ri.Cvar_Get( "r_stencilbits", "8", CVAR_ARCHIVE | CVAR_LATCH );
 	r_ext_multisample = ri.Cvar_Get( "r_ext_multisample", "0", CVAR_ARCHIVE | CVAR_LATCH );
-	ri.Cvar_CheckRange( r_ext_multisample, "0", "4", CV_INTEGER );
+	ri.Cvar_CheckRange( r_ext_multisample, "0", "8", CV_INTEGER );
 	r_overBrightBits = ri.Cvar_Get ("r_overBrightBits", "1", CVAR_ARCHIVE | CVAR_LATCH );
 	r_ignorehwgamma = ri.Cvar_Get( "r_ignorehwgamma", "0", CVAR_ARCHIVE | CVAR_LATCH);
 	r_simpleMipMaps = ri.Cvar_Get( "r_simpleMipMaps", "1", CVAR_ARCHIVE | CVAR_LATCH );


### PR DESCRIPTION
Quake3e version of https://github.com/ioquake/ioq3/pull/487.

This makes it possible to use 8× MSAA with the OpenGL 2.x renderer. (In Quake3e, this was already possible with OpenGL 1.x and Vulkan).