### PR TITLE
Fixed l_memory/MEMORYMANAGER.

### DIFF
--- a/code/botlib/l_memory.c
+++ b/code/botlib/l_memory.c
@@ -36,16 +36,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "be_interface.h"
 
 //#define MEMDEBUG
-//#define MEMORYMANEGER
+//#define MEMORYMANAGER
 
 #define MEM_ID		0x12345678l
 #define HUNK_ID		0x87654321l
 
-int allocatedmemory;
-int totalmemorysize;
-int numblocks;
+#ifdef MEMORYMANAGER
 
-#ifdef MEMORYMANEGER
+static int allocatedmemory;
+static int totalmemorysize;
+static int numblocks;
 
 typedef struct memoryblock_s
 {


### PR DESCRIPTION
# Sligthly improve compiling of #ifdef MEMORYMANEGER.
There are three ints (allocatedmemory, totalmemorysize, numblocks) that should be static since they are only used inside l_memory.c (and they are only used with #ifdef MEMORYMANEGER), so I declared them static and moved them down a few lines..
Moreover MEMORYMAN**E**GER is spelled wrong, it should be called MEMORYMAN**A**GER.
## ***What is changing:***
  + fixes potential compiler warnings.
  + renamed MEMORYMAN**E**GER to MEMORYMAN**A**GER.