### PR TITLE
Always keep bots, even with 'devmap'.

### DIFF
--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -196,13 +196,14 @@ static void SV_Map_f( void ) {
 	else {
 		if ( !Q_stricmp( cmd, "devmap" ) ) {
 			cheat = qtrue;
-			killBots = qtrue;
 		} else {
 			cheat = qfalse;
-			killBots = qfalse;
 		}
 		if( sv_gametype->integer == GT_SINGLE_PLAYER ) {
 			Cvar_SetIntegerValue( "g_gametype", GT_FFA );
+			killBots = qtrue;
+		} else {
+			killBots = qfalse;
 		}
 	}
 


### PR DESCRIPTION
# Keep (multiplayer) bots if a new map is started in developer mode.
Currently bots will be automatically kicked from server if a new map is loading, when the map was called via \devmap command.
If a map is called via regular \map command, the bots will not get kicked.
For (bot) development purposes it would be very comfortable if the bots will also move on to a new map even in developer mode. Especially because a few bot related cvars are only changeable if cheats are enabled (which is absurd when the bots are kicked to make use of these cvars.)
It's very frustrating if someone adds 64 bots, starts a map with a \devmap command and has to manually add 64 bots again.
## ***What is changing:***
  + In multiplayer games bots will no longer get kicked from server if a new map is started via \devmap command.
## ***Notes:***
  + The default 'Singleplayer' behaviour remains the same (bots will be kicked anyways).
  + Bots can still be easily kicked, via \kick commands.
  + The code logic remains a bit messy, but I leave it untouched to not break existing behaviour (spdevmap/spmap cmd).
  + Tested with baseq3, Hunt, PK-Arena, Generations Arena, Team Arena and a few other mods.
  + I have to admit, this is really a 'quality of life' feature for developers, not a bugfix.
  + Zturtleman also merged this pull request into [Spearmint](https://github.com/zturtleman/spearmint/commit/1ce702f408308027f73823a12b26ad0c5304b0ed) recently.