### PR TITLE
Added kicknum, kickall, and kickbots commands, patch by Ensiform.

### DIFF
--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -439,17 +439,17 @@ static void SV_KickBots_f( void ) {
 	int			i;
 
 	// make sure server is running
-	if( !com_sv_running->integer ) {
+	if ( !com_sv_running->integer ) {
 		Com_Printf("Server is not running.\n");
 		return;
 	}
 
 	for( i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++ ) {
-		if( !cl->state ) {
+		if ( cl->state >= CS_CONNECTED ) {
 			continue;
 		}
 
-		if( cl->netchan.remoteAddress.type != NA_BOT ) {
+		if ( cl->netchan.remoteAddress.type != NA_BOT ) {
 			continue;
 		}
 
@@ -469,17 +469,17 @@ static void SV_KickAll_f( void ) {
 	int i;
 
 	// make sure server is running
-	if( !com_sv_running->integer ) {
+	if ( !com_sv_running->integer ) {
 		Com_Printf( "Server is not running.\n" );
 		return;
 	}
 
 	for( i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++ ) {
-		if( !cl->state ) {
+		if ( cl->state >= CS_CONNECTED ) {
 			continue;
 		}
 
-		if( cl->netchan.remoteAddress.type == NA_LOOPBACK ) {
+		if ( cl->netchan.remoteAddress.type == NA_LOOPBACK ) {
 			continue;
 		}
 
@@ -513,7 +513,7 @@ static void SV_KickNum_f( void ) {
 	if ( !cl ) {
 		return;
 	}
-	if( cl->netchan.remoteAddress.type == NA_LOOPBACK ) {
+	if ( cl->netchan.remoteAddress.type == NA_LOOPBACK ) {
 		Com_Printf("Cannot kick host player\n");
 		return;
 	}

--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -445,7 +445,7 @@ static void SV_KickBots_f( void ) {
 	}
 
 	for( i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++ ) {
-		if ( cl->state >= CS_CONNECTED ) {
+		if ( cl->state < CS_CONNECTED ) {
 			continue;
 		}
 
@@ -475,7 +475,7 @@ static void SV_KickAll_f( void ) {
 	}
 
 	for( i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++ ) {
-		if ( cl->state >= CS_CONNECTED ) {
+		if ( cl->state < CS_CONNECTED ) {
 			continue;
 		}
 


### PR DESCRIPTION
# Extended 'kick' commands.
This is an exact merge of Ensiform's patch from here: https://github.com/ioquake/ioq3/commit/afa607c3b6ffed633797822871e4c4dcce124b58#diff-7357892ed859d7961b2dce3cdfdc28519c4a3781a9e4a7431226171ebed64298, and it makes life easier for people migrating from other idtech3 engines that are used to these commands.

## ***What is changing:***
  + 'bots' and 'all' clients can be kicked at once via 'kickbots' and 'kickall' command, or via 'kicknum'.
## ***Notes:***
  + This piece of code is well tested in other ioquake3 based engines (Spearmint, WoP, etc.).
  + These changes fix annoying differences in handling relatively uniform engines (user experience).
  + All this cool work was made by Ensiform and was applied by Zturtleman. I am not the author of this work.
  
  Thank you @ensiform!