### PR TITLE
Add con_autoclear cvar.

### DIFF
--- a/code/client/cl_console.c
+++ b/code/client/cl_console.c
@@ -70,6 +70,7 @@ extern  int         chat_playerNum;
 console_t	con;
 
 cvar_t		*con_conspeed;
+cvar_t		*con_autoclear;
 cvar_t		*con_notifytime;
 cvar_t		*con_scale;
 
@@ -88,7 +89,10 @@ void Con_ToggleConsole_f( void ) {
 		return;
 	}
 
-	Field_Clear( &g_consoleField );
+	if ( con_autoclear->integer ) {
+		Field_Clear( &g_consoleField );
+	}
+
 	g_consoleField.widthInChars = g_console_field_width;
 
 	Con_ClearNotify();
@@ -393,7 +397,7 @@ void Con_Init( void )
 {
 	con_notifytime = Cvar_Get( "con_notifytime", "3", 0 );
 	con_conspeed = Cvar_Get( "scr_conspeed", "3", 0 );
-
+	con_autoclear = Cvar_Get("con_autoclear", "1", CVAR_ARCHIVE_ND);
 	con_scale = Cvar_Get( "con_scale", "1", CVAR_ARCHIVE_ND );
 	Cvar_CheckRange( con_scale, "0.5", "8", CV_FLOAT );
 


### PR DESCRIPTION
# Add a new cvar called 'con_autoclear'.
This is extracted from here: https://github.com/ioquake/ioq3/commit/dfce71929a1094526f6482eeb6a0cca11f4bc7a1.
These changes will also make life easier for people that are used to this cvar ('con_autoclear' is also available in ETe).
Actually it would be nice to have 'con_autochat' available as well for Q3e, unfortunately I have to admit that I'm a bit unsure if it would work as expected in Q3e.

## ***What is changing:***
  + Setting the new cvar 'con_autoclear' to 0 will disable clearing console input text when console is closed (default 1).
## ***Notes:***
  + This piece of code is well tested in other ioquake3 based engines (Spearmint, WoP, etc.).
  + These changes fix annoying differences in handling relatively uniform engines (user experience).
  + Again, this work was NOT made by me, Zturtleman merged this into ioquake3.