### PR TITLE
Fix client forgetting password when it is set in main menu

### DIFF
--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -3916,7 +3916,7 @@ void CL_Init( void ) {
 	Cvar_Get ("sex", "male", CVAR_USERINFO | CVAR_ARCHIVE_ND );
 	Cvar_Get ("cl_anonymous", "0", CVAR_USERINFO | CVAR_ARCHIVE_ND );
 
-	Cvar_Get ("password", "", CVAR_USERINFO);
+	Cvar_Get ("password", "", CVAR_USERINFO | CVAR_NORESTART);
 	Cvar_Get ("cg_predictItems", "1", CVAR_USERINFO | CVAR_ARCHIVE );
 
 


### PR DESCRIPTION
Scenario is the following:
1. Player opens quake3e and goes to server browser in main menu
2. Player connects to a server with a mod different than baseq3 and a password
3. "Invalid Password" message appears on the connecting screen
4. Player types password in console
5. Quake3e connects to the server and player enters the game
6. Server changes map after a while

What happens now is that player gets kicked due to invalid password, what should happen is that player can stay on the server after entering password once.

"password" cvar was restored to its default value (empty string) in point 4 when fs_game changed upon connection (in Com_GameRestart -> Cvar_Restart()).

The only downside to using CVAR_NORESTART is that client may leak password when he decides to change server. I don't think it's a big deal considering level of security of these passwords in general, but this could be fixed by comparing ip address and resetting password when connecting to another server. Let me know if you think this is required to merge.