### PR TITLE
Use scancodes for SDL input

### DIFF
--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "sdl_glw.h"
 
 static cvar_t *in_keyboardDebug;
+static cvar_t *in_forceCharset;
 
 #ifdef USE_JOYSTICK
 static SDL_GameController *gamepad;
@@ -217,28 +218,31 @@ static keyNum_t IN_TranslateSDLToQ3Key( SDL_Keysym *keysym, qboolean down )
 		else
 			key = '1' + keysym->scancode - SDL_SCANCODE_1;
 	}
-	else if( keysym->scancode >= SDL_SCANCODE_A && keysym->scancode <= SDL_SCANCODE_Z )
+	else if ( in_forceCharset->integer > 0 )
 	{
-		key = 'a' + keysym->scancode - SDL_SCANCODE_A;
-	}
-	else
-	{
-		switch( keysym->scancode )
+		if ( keysym->scancode >= SDL_SCANCODE_A && keysym->scancode <= SDL_SCANCODE_Z )
 		{
-			case SDL_SCANCODE_MINUS:        key = '-';  break;
-			case SDL_SCANCODE_EQUALS:       key = '=';  break;
-			case SDL_SCANCODE_LEFTBRACKET:  key = '[';  break;
-			case SDL_SCANCODE_RIGHTBRACKET: key = ']';  break;
-			case SDL_SCANCODE_NONUSBACKSLASH:
-			case SDL_SCANCODE_BACKSLASH:    key = '\\'; break;
-			case SDL_SCANCODE_SEMICOLON:    key = ';';  break;
-			case SDL_SCANCODE_APOSTROPHE:   key = '\''; break;
-			case SDL_SCANCODE_COMMA:        key = ',';  break;
-			case SDL_SCANCODE_PERIOD:       key = '.';  break;
-			case SDL_SCANCODE_SLASH:        key = '/';  break;
-			default:
-				/* key = 0 */
-				break;
+			key = 'a' + keysym->scancode - SDL_SCANCODE_A;
+		}
+		else
+		{
+			switch ( keysym->scancode )
+			{
+				case SDL_SCANCODE_MINUS:        key = '-';  break;
+				case SDL_SCANCODE_EQUALS:       key = '=';  break;
+				case SDL_SCANCODE_LEFTBRACKET:  key = '[';  break;
+				case SDL_SCANCODE_RIGHTBRACKET: key = ']';  break;
+				case SDL_SCANCODE_NONUSBACKSLASH:
+				case SDL_SCANCODE_BACKSLASH:    key = '\\'; break;
+				case SDL_SCANCODE_SEMICOLON:    key = ';';  break;
+				case SDL_SCANCODE_APOSTROPHE:   key = '\''; break;
+				case SDL_SCANCODE_COMMA:        key = ',';  break;
+				case SDL_SCANCODE_PERIOD:       key = '.';  break;
+				case SDL_SCANCODE_SLASH:        key = '/';  break;
+				default:
+					/* key = 0 */
+					break;
+			}
 		}
 	}
 
@@ -1357,6 +1361,7 @@ void IN_Init( void )
 	Com_DPrintf( "\n------- Input Initialization -------\n" );
 
 	in_keyboardDebug = Cvar_Get( "in_keyboardDebug", "0", CVAR_ARCHIVE );
+	in_forceCharset = Cvar_Get( "in_forceCharset", "1", CVAR_ARCHIVE_ND );
 
 	// mouse variables
 	in_mouse = Cvar_Get( "in_mouse", "1", CVAR_ARCHIVE );

--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -217,12 +217,37 @@ static keyNum_t IN_TranslateSDLToQ3Key( SDL_Keysym *keysym, qboolean down )
 		else
 			key = '1' + keysym->scancode - SDL_SCANCODE_1;
 	}
-	else if( keysym->sym >= SDLK_SPACE && keysym->sym < SDLK_DELETE )
+	else if( keysym->scancode >= SDL_SCANCODE_A && keysym->scancode <= SDL_SCANCODE_Z )
+	{
+		key = 'a' + keysym->scancode - SDL_SCANCODE_A;
+	}
+	else
+	{
+		switch( keysym->scancode )
+		{
+			case SDL_SCANCODE_MINUS:        key = '-';  break;
+			case SDL_SCANCODE_EQUALS:       key = '=';  break;
+			case SDL_SCANCODE_LEFTBRACKET:  key = '[';  break;
+			case SDL_SCANCODE_RIGHTBRACKET: key = ']';  break;
+			case SDL_SCANCODE_NONUSBACKSLASH:
+			case SDL_SCANCODE_BACKSLASH:    key = '\\'; break;
+			case SDL_SCANCODE_SEMICOLON:    key = ';';  break;
+			case SDL_SCANCODE_APOSTROPHE:   key = '\''; break;
+			case SDL_SCANCODE_COMMA:        key = ',';  break;
+			case SDL_SCANCODE_PERIOD:       key = '.';  break;
+			case SDL_SCANCODE_SLASH:        key = '/';  break;
+			default:
+				/* key = 0 */
+				break;
+		}
+	}
+
+	if( !key && keysym->sym >= SDLK_SPACE && keysym->sym < SDLK_DELETE )
 	{
 		// These happen to match the ASCII chars
 		key = (int)keysym->sym;
 	}
-	else
+	else if( !key )
 	{
 		switch( keysym->sym )
 		{


### PR DESCRIPTION
This changes SDL keyboard input to use scancodes for all keys moved on typical layouts, bringing its function in line with the win32 backend and adding support for non-latin keyboard layouts (AZERTY/Dvorak/etc are usable by rebinding, but Cyrillic/Greek are not).

Problems:
- Existing non-QWERTY SDL users with rebound keys will have wrong binds
- Native X11 backend still uses translated keycodes