### PR TITLE
DRAFT: Define static functions as such.

### DIFF
--- a/code/botlib/be_aas_bspq3.c
+++ b/code/botlib/be_aas_bspq3.c
@@ -85,7 +85,7 @@ typedef struct bsp_s
 } bsp_t;
 
 //global bsp
-bsp_t bspworld;
+static bsp_t bspworld;
 
 
 #ifdef BSP_DEBUG

--- a/code/botlib/be_aas_cluster.c
+++ b/code/botlib/be_aas_cluster.c
@@ -53,7 +53,7 @@ extern botlib_import_t botimport;
 #define MAX_PORTALAREAS			1024
 
 // do not flood through area faces, only use reachabilities
-int nofaceflood = qtrue;
+static int nofaceflood = qtrue;
 
 //===========================================================================
 //
@@ -61,7 +61,7 @@ int nofaceflood = qtrue;
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_RemoveClusterAreas(void)
+static void AAS_RemoveClusterAreas(void)
 {
 	int i;
 
@@ -116,7 +116,7 @@ void AAS_RemovePortalsClusterReference(int clusternum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_UpdatePortal(int areanum, int clusternum)
+static int AAS_UpdatePortal(int areanum, int clusternum)
 {
 	int portalnum;
 	aas_portal_t *portal;
@@ -175,7 +175,7 @@ int AAS_UpdatePortal(int areanum, int clusternum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_FloodClusterAreas_r(int areanum, int clusternum)
+static int AAS_FloodClusterAreas_r(int areanum, int clusternum)
 {
 	aas_area_t *area;
 	aas_face_t *face;
@@ -248,7 +248,7 @@ int AAS_FloodClusterAreas_r(int areanum, int clusternum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_FloodClusterAreasUsingReachabilities(int clusternum)
+static int AAS_FloodClusterAreasUsingReachabilities(int clusternum)
 {
 	int i, j, areanum;
 
@@ -313,7 +313,7 @@ void AAS_NumberClusterPortals(int clusternum)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_NumberClusterAreas(int clusternum)
+static void AAS_NumberClusterAreas(int clusternum)
 {
 	int i, portalnum;
 	aas_cluster_t *cluster;
@@ -387,7 +387,7 @@ void AAS_NumberClusterAreas(int clusternum)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_FindClusters(void)
+static int AAS_FindClusters(void)
 {
 	int i;
 	aas_cluster_t *cluster;
@@ -437,7 +437,7 @@ int AAS_FindClusters(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_CreatePortals(void)
+static void AAS_CreatePortals(void)
 {
 	int i;
 	aas_portal_t *portal;
@@ -685,7 +685,7 @@ qboolean AAS_CanMergeFaces(int *facenums, int numfaces, int planenum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_ConnectedAreas_r(int *areanums, int numareas, int *connectedareas, int curarea)
+static void AAS_ConnectedAreas_r(int *areanums, int numareas, int *connectedareas, int curarea)
 {
 	int i, j, otherareanum, facenum;
 	aas_area_t *area;
@@ -721,7 +721,7 @@ void AAS_ConnectedAreas_r(int *areanums, int numareas, int *connectedareas, int 
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-qboolean AAS_ConnectedAreas(int *areanums, int numareas)
+static qboolean AAS_ConnectedAreas(int *areanums, int numareas)
 {
 	int connectedareas[MAX_PORTALAREAS], i;
 
@@ -742,7 +742,7 @@ qboolean AAS_ConnectedAreas(int *areanums, int numareas)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_GetAdjacentAreasWithLessPresenceTypes_r(int *areanums, int numareas, int curareanum)
+static int AAS_GetAdjacentAreasWithLessPresenceTypes_r(int *areanums, int numareas, int curareanum)
 {
 	int i, j, presencetype, otherpresencetype, otherareanum, facenum;
 	aas_area_t *area;
@@ -791,7 +791,7 @@ int AAS_GetAdjacentAreasWithLessPresenceTypes_r(int *areanums, int numareas, int
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_CheckAreaForPossiblePortals(int areanum)
+static int AAS_CheckAreaForPossiblePortals(int areanum)
 {
 	int i, j, k, fen, ben, frontedgenum, backedgenum, facenum;
 	int areanums[MAX_PORTALAREAS], numareas, otherareanum;
@@ -918,7 +918,7 @@ int AAS_CheckAreaForPossiblePortals(int areanum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_FindPossiblePortals(void)
+static void AAS_FindPossiblePortals(void)
 {
 	int i, numpossibleportals;
 
@@ -1370,7 +1370,7 @@ void AAS_AddTeleporterPortals(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_TestPortals(void)
+static int AAS_TestPortals(void)
 {
 	int i;
 	aas_portal_t *portal;
@@ -1399,7 +1399,7 @@ int AAS_TestPortals(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_CountForcedClusterPortals(void)
+static void AAS_CountForcedClusterPortals(void)
 {
 	int num, i;
 
@@ -1420,7 +1420,7 @@ void AAS_CountForcedClusterPortals(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_CreateViewPortals(void)
+static void AAS_CreateViewPortals(void)
 {
 	int i;
 

--- a/code/botlib/be_aas_debug.c
+++ b/code/botlib/be_aas_debug.c
@@ -45,9 +45,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define MAX_DEBUGLINES				1024
 #define MAX_DEBUGPOLYGONS			8192
 
-int debuglines[MAX_DEBUGLINES];
-int debuglinevisible[MAX_DEBUGLINES];
-int numdebuglines;
+static int debuglines[MAX_DEBUGLINES];
+static int debuglinevisible[MAX_DEBUGLINES];
+static int numdebuglines;
 
 static int debugpolygons[MAX_DEBUGPOLYGONS];
 
@@ -81,7 +81,7 @@ void AAS_ClearShownPolygons(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_ShowPolygon(int color, int numpoints, vec3_t *points)
+static void AAS_ShowPolygon(int color, int numpoints, vec3_t *points)
 {
 	int i;
 
@@ -346,7 +346,7 @@ void AAS_ShowFace(int facenum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_ShowFacePolygon(int facenum, int color, int flip)
+static void AAS_ShowFacePolygon(int facenum, int color, int flip)
 {
 	int i, edgenum, numpoints;
 	vec3_t points[128];
@@ -710,7 +710,7 @@ void AAS_ShowReachableAreas(int areanum)
 	AAS_ShowReachability(&reach);
 } //end of the function ShowReachableAreas
 
-void AAS_FloodAreas_r(int areanum, int cluster, int *done)
+static void AAS_FloodAreas_r(int areanum, int cluster, int *done)
 {
 	int nextareanum, i, facenum;
 	aas_area_t *area;

--- a/code/botlib/be_aas_file.c
+++ b/code/botlib/be_aas_file.c
@@ -51,7 +51,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_SwapAASData(void)
+static void AAS_SwapAASData(void)
 {
 	int i, j;
 	//bounding boxes
@@ -237,7 +237,7 @@ void AAS_DumpAASData(void)
 // Changes Globals:		-
 //===========================================================================
 #ifdef AASFILEDEBUG
-void AAS_FileInfo(void)
+static void AAS_FileInfo(void)
 {
 	int i, n, optimized;
 
@@ -287,7 +287,7 @@ void AAS_FileInfo(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-char *AAS_LoadAASLump(fileHandle_t fp, int offset, int length, int *lastoffset, int size)
+static char *AAS_LoadAASLump(fileHandle_t fp, int offset, int length, int *lastoffset, int size)
 {
 	char *buf;
 	//
@@ -324,7 +324,7 @@ char *AAS_LoadAASLump(fileHandle_t fp, int offset, int length, int *lastoffset, 
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_DData(unsigned char *data, int size)
+static void AAS_DData(unsigned char *data, int size)
 {
 	int i;
 
@@ -495,7 +495,7 @@ int AAS_LoadAASFile(char *filename)
 //===========================================================================
 static int AAS_WriteAASLump_offset;
 
-int AAS_WriteAASLump(fileHandle_t fp, aas_header_t *h, int lumpnum, void *data, int length)
+static int AAS_WriteAASLump(fileHandle_t fp, aas_header_t *h, int lumpnum, void *data, int length)
 {
 	aas_lump_t *lump;
 

--- a/code/botlib/be_aas_main.c
+++ b/code/botlib/be_aas_main.c
@@ -90,7 +90,7 @@ int AAS_Initialized(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_SetInitialized(void)
+static void AAS_SetInitialized(void)
 {
 	aasworld.initialized = qtrue;
 	botimport.Print(PRT_MESSAGE, "AAS initialized.\n");
@@ -217,7 +217,7 @@ void AAS_ProjectPointOntoVector( vec3_t point, vec3_t vStart, vec3_t vEnd, vec3_
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_LoadFiles(const char *mapname)
+static int AAS_LoadFiles(const char *mapname)
 {
 	int errnum;
 	char aasfile[MAX_PATH];

--- a/code/botlib/be_aas_main.h
+++ b/code/botlib/be_aas_main.h
@@ -35,8 +35,6 @@ extern aas_t aasworld;
 
 //AAS error message
 void QDECL AAS_Error(char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
-//set AAS initialized
-void AAS_SetInitialized(void);
 //setup AAS with the given number of entities and clients
 int AAS_Setup(void);
 //shutdown AAS

--- a/code/botlib/be_aas_move.c
+++ b/code/botlib/be_aas_move.c
@@ -287,7 +287,7 @@ void AAS_JumpReachRunStart(aas_reachability_t *reach, vec3_t runstart)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-float AAS_WeaponJumpZVelocity(vec3_t origin, float radiusdamage)
+static float AAS_WeaponJumpZVelocity(vec3_t origin, float radiusdamage)
 {
 	vec3_t kvel, v, start, end, forward, right, viewangles, dir;
 	float	mass, knockback, points;
@@ -361,7 +361,7 @@ float AAS_BFGJumpZVelocity(vec3_t origin)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_Accelerate(vec3_t velocity, float frametime, vec3_t wishdir, float wishspeed, float accel)
+static void AAS_Accelerate(vec3_t velocity, float frametime, vec3_t wishdir, float wishspeed, float accel)
 {
 	// q2 style
 	int			i;
@@ -388,7 +388,7 @@ void AAS_Accelerate(vec3_t velocity, float frametime, vec3_t wishdir, float wish
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_ApplyFriction(vec3_t vel, float friction, float stopspeed,
+static void AAS_ApplyFriction(vec3_t vel, float friction, float stopspeed,
 													float frametime)
 {
 	float speed, control, newspeed;

--- a/code/botlib/be_aas_optimize.c
+++ b/code/botlib/be_aas_optimize.c
@@ -75,7 +75,7 @@ typedef struct optimized_s
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_KeepEdge(aas_edge_t *edge)
+static int AAS_KeepEdge(aas_edge_t *edge)
 {
 	return 1;
 } //end of the function AAS_KeepFace
@@ -85,7 +85,7 @@ int AAS_KeepEdge(aas_edge_t *edge)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_OptimizeEdge(optimized_t *optimized, int edgenum)
+static int AAS_OptimizeEdge(optimized_t *optimized, int edgenum)
 {
 	int i, optedgenum;
 	aas_edge_t *edge, *optedge;
@@ -130,7 +130,7 @@ int AAS_OptimizeEdge(optimized_t *optimized, int edgenum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_KeepFace(aas_face_t *face)
+static int AAS_KeepFace(aas_face_t *face)
 {
 	if (!(face->faceflags & FACE_LADDER)) return 0;
 	else return 1;
@@ -141,7 +141,7 @@ int AAS_KeepFace(aas_face_t *face)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_OptimizeFace(optimized_t *optimized, int facenum)
+static int AAS_OptimizeFace(optimized_t *optimized, int facenum)
 {
 	int i, edgenum, optedgenum, optfacenum;
 	aas_face_t *face, *optface;
@@ -186,7 +186,7 @@ int AAS_OptimizeFace(optimized_t *optimized, int facenum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_OptimizeArea(optimized_t *optimized, int areanum)
+static void AAS_OptimizeArea(optimized_t *optimized, int areanum)
 {
 	int i, facenum, optfacenum;
 	aas_area_t *area, *optarea;
@@ -215,7 +215,7 @@ void AAS_OptimizeArea(optimized_t *optimized, int areanum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_OptimizeAlloc(optimized_t *optimized)
+static void AAS_OptimizeAlloc(optimized_t *optimized)
 {
 	optimized->vertexes = (aas_vertex_t *) GetClearedMemory(aasworld.numvertexes * sizeof(aas_vertex_t));
 	optimized->numvertexes = 0;
@@ -240,7 +240,7 @@ void AAS_OptimizeAlloc(optimized_t *optimized)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_OptimizeStore(optimized_t *optimized)
+static void AAS_OptimizeStore(optimized_t *optimized)
 {
 	//store the optimized vertexes
 	if (aasworld.vertexes) FreeMemory(aasworld.vertexes);

--- a/code/botlib/be_aas_reach.c
+++ b/code/botlib/be_aas_reach.c
@@ -62,25 +62,25 @@ extern botlib_import_t botimport;
 //area flag used for weapon jumping
 #define AREA_WEAPONJUMP						8192	//valid area to weapon jump to
 //number of reachabilities of each type
-int reach_swim;			//swim
-int reach_equalfloor;	//walk on floors with equal height
-int reach_step;			//step up
-int reach_walk;			//walk of step
-int reach_barrier;		//jump up to a barrier
-int reach_waterjump;	//jump out of water
-int reach_walkoffledge;	//walk of a ledge
-int reach_jump;			//jump
-int reach_ladder;		//climb or descent a ladder
-int reach_teleport;		//teleport
-int reach_elevator;		//use an elevator
-int reach_funcbob;		//use a func bob
-int reach_grapple;		//grapple hook
+static int reach_swim;			//swim
+static int reach_equalfloor;	//walk on floors with equal height
+static int reach_step;			//step up
+static int reach_walk;			//walk of step
+static int reach_barrier;		//jump up to a barrier
+static int reach_waterjump;	//jump out of water
+static int reach_walkoffledge;	//walk of a ledge
+static int reach_jump;			//jump
+static int reach_ladder;		//climb or descent a ladder
+static int reach_teleport;		//teleport
+static int reach_elevator;		//use an elevator
+static int reach_funcbob;		//use a func bob
+static int reach_grapple;		//grapple hook
 int reach_doublejump;	//double jump
 int reach_rampjump;		//ramp jump
 int reach_strafejump;	//strafe jump (just normal jump but further)
-int reach_rocketjump;	//rocket jump
+static int reach_rocketjump;	//rocket jump
 int reach_bfgjump;		//bfg jump
-int reach_jumppad;		//jump pads
+static int reach_jumppad;		//jump pads
 //if true grapple reachabilities are skipped
 int calcgrapplereach;
 //linked reachability
@@ -97,10 +97,10 @@ typedef struct aas_lreachability_s
 	struct aas_lreachability_s *next;
 } aas_lreachability_t;
 //temporary reachabilities
-aas_lreachability_t *reachabilityheap;	//heap with reachabilities
-aas_lreachability_t *nextreachability;	//next free reachability from the heap
-aas_lreachability_t **areareachability;	//reachability links for every area
-int numlreachabilities;
+static aas_lreachability_t *reachabilityheap;	//heap with reachabilities
+static aas_lreachability_t *nextreachability;	//next free reachability from the heap
+static aas_lreachability_t **areareachability;	//reachability links for every area
+static int numlreachabilities;
 
 //===========================================================================
 // returns the surface area of the given face
@@ -109,7 +109,7 @@ int numlreachabilities;
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-float AAS_FaceArea(aas_face_t *face)
+static float AAS_FaceArea(aas_face_t *face)
 {
 	int i, edgenum, side;
 	float total;
@@ -142,7 +142,7 @@ float AAS_FaceArea(aas_face_t *face)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-float AAS_AreaVolume(int areanum)
+static float AAS_AreaVolume(int areanum)
 {
 	int i, edgenum, facenum, side;
 	vec_t d, a, volume;
@@ -210,7 +210,7 @@ int AAS_BestReachableLinkArea(aas_link_t *areas)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_GetJumpPadInfo(int ent, vec3_t areastart, vec3_t absmins, vec3_t absmaxs, vec3_t velocity)
+static int AAS_GetJumpPadInfo(int ent, vec3_t areastart, vec3_t absmins, vec3_t absmaxs, vec3_t velocity)
 {
 	int modelnum, ent2;
 	float speed, height, gravity, time, dist, forward;
@@ -452,7 +452,7 @@ int AAS_BestReachableArea(vec3_t origin, vec3_t mins, vec3_t maxs, vec3_t goalor
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_SetupReachabilityHeap(void)
+static void AAS_SetupReachabilityHeap(void)
 {
 	int i;
 
@@ -472,7 +472,7 @@ void AAS_SetupReachabilityHeap(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_ShutDownReachabilityHeap(void)
+static void AAS_ShutDownReachabilityHeap(void)
 {
 	FreeMemory(reachabilityheap);
 	numlreachabilities = 0;
@@ -484,7 +484,7 @@ void AAS_ShutDownReachabilityHeap(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-aas_lreachability_t *AAS_AllocReachability(void)
+static aas_lreachability_t *AAS_AllocReachability(void)
 {
 	aas_lreachability_t *r;
 
@@ -504,7 +504,7 @@ aas_lreachability_t *AAS_AllocReachability(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_FreeReachability(aas_lreachability_t *lreach)
+static void AAS_FreeReachability(aas_lreachability_t *lreach)
 {
 	Com_Memset(lreach, 0, sizeof(aas_lreachability_t));
 
@@ -560,7 +560,7 @@ float AAS_AreaGroundFaceArea(int areanum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_FaceCenter(int facenum, vec3_t center)
+static void AAS_FaceCenter(int facenum, vec3_t center)
 {
 	int i;
 	float scale;
@@ -587,7 +587,7 @@ void AAS_FaceCenter(int facenum, vec3_t center)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_FallDamageDistance(void)
+static int AAS_FallDamageDistance(void)
 {
 	float maxzvelocity, gravity, t;
 
@@ -605,7 +605,7 @@ int AAS_FallDamageDistance(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-float AAS_FallDelta(float distance)
+static float AAS_FallDelta(float distance)
 {
 	float t, delta, gravity;
 
@@ -620,7 +620,7 @@ float AAS_FallDelta(float distance)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-float AAS_MaxJumpHeight(float phys_jumpvel)
+static float AAS_MaxJumpHeight(float phys_jumpvel)
 {
 	float phys_gravity;
 
@@ -635,7 +635,7 @@ float AAS_MaxJumpHeight(float phys_jumpvel)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-float AAS_MaxJumpDistance(float phys_jumpvel)
+static float AAS_MaxJumpDistance(float phys_jumpvel)
 {
 	float phys_gravity, phys_maxvelocity, t;
 
@@ -720,7 +720,7 @@ int AAS_AreaGrounded(int areanum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_AreaLadder(int areanum)
+static int AAS_AreaLadder(int areanum)
 {
 	return (aasworld.areasettings[areanum].areaflags & AREA_LADDER);
 } //end of the function AAS_AreaLadder
@@ -740,7 +740,7 @@ int AAS_AreaJumpPad(int areanum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_AreaTeleporter(int areanum)
+static int AAS_AreaTeleporter(int areanum)
 {
 	return (aasworld.areasettings[areanum].contents & AREACONTENTS_TELEPORTER);
 } //end of the function AAS_AreaTeleporter
@@ -750,7 +750,7 @@ int AAS_AreaTeleporter(int areanum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_AreaClusterPortal(int areanum)
+static int AAS_AreaClusterPortal(int areanum)
 {
 	return (aasworld.areasettings[areanum].contents & AREACONTENTS_CLUSTERPORTAL);
 } //end of the function AAS_AreaClusterPortal
@@ -782,7 +782,7 @@ unsigned short int AAS_BarrierJumpTravelTime(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-qboolean AAS_ReachabilityExists(int area1num, int area2num)
+static qboolean AAS_ReachabilityExists(int area1num, int area2num)
 {
 	aas_lreachability_t *r;
 
@@ -832,7 +832,7 @@ int AAS_NearbySolidOrGap(vec3_t start, vec3_t end)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_Reachability_Swim(int area1num, int area2num)
+static int AAS_Reachability_Swim(int area1num, int area2num)
 {
 	int i, j, face1num, face2num, side1;
 	aas_area_t *area1, *area2;
@@ -907,7 +907,7 @@ int AAS_Reachability_Swim(int area1num, int area2num)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_Reachability_EqualFloorHeight(int area1num, int area2num)
+static int AAS_Reachability_EqualFloorHeight(int area1num, int area2num)
 {
 	int i, j, edgenum, edgenum1, edgenum2, foundreach, side;
 	float height, bestheight, length, bestlength;
@@ -1053,7 +1053,7 @@ int AAS_Reachability_EqualFloorHeight(int area1num, int area2num)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_Reachability_Step_Barrier_WaterJump_WalkOffLedge(int area1num, int area2num)
+static int AAS_Reachability_Step_Barrier_WaterJump_WalkOffLedge(int area1num, int area2num)
 {
 	int i, j, k, l, edge1num, edge2num, areas[10], numareas;
 	int ground_bestarea2groundedgenum, ground_foundreach;
@@ -1831,7 +1831,7 @@ float AAS_ClosestEdgePoints(vec3_t v1, vec3_t v2, vec3_t v3, vec3_t v4,
 	return bestdist;
 } //end of the function AAS_ClosestEdgePoints*/
 
-float AAS_ClosestEdgePoints(vec3_t v1, vec3_t v2, vec3_t v3, vec3_t v4,
+static float AAS_ClosestEdgePoints(vec3_t v1, vec3_t v2, vec3_t v3, vec3_t v4,
 							aas_plane_t *plane1, aas_plane_t *plane2,
 							vec3_t beststart1, vec3_t bestend1,
 							vec3_t beststart2, vec3_t bestend2, float bestdist)
@@ -2109,7 +2109,7 @@ float AAS_ClosestEdgePoints(vec3_t v1, vec3_t v2, vec3_t v3, vec3_t v4,
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_Reachability_Jump(int area1num, int area2num)
+static int AAS_Reachability_Jump(int area1num, int area2num)
 {
 	int i, j, k, l, face1num, face2num, edge1num, edge2num, traveltype;
 	int stopevent, areas[10], numareas;
@@ -2380,7 +2380,7 @@ int AAS_Reachability_Jump(int area1num, int area2num)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_Reachability_Ladder(int area1num, int area2num)
+static int AAS_Reachability_Ladder(int area1num, int area2num)
 {
 	int i, j, k, l, edge1num, edge2num, sharededgenum = 0, lowestedgenum = 0;
 	int face1num, face2num, ladderface1num = 0, ladderface2num = 0;
@@ -2714,7 +2714,7 @@ int AAS_Reachability_Ladder(int area1num, int area2num)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_TravelFlagsForTeam(int ent)
+static int AAS_TravelFlagsForTeam(int ent)
 {
 	int notteam;
 
@@ -2744,7 +2744,7 @@ int AAS_TravelFlagsForTeam(int ent)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_Reachability_Teleport(void)
+static void AAS_Reachability_Teleport(void)
 {
 	int area1num, area2num;
 	char target[MAX_EPAIRKEY], targetname[MAX_EPAIRKEY];
@@ -2938,7 +2938,7 @@ void AAS_Reachability_Teleport(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_Reachability_Elevator(void)
+static void AAS_Reachability_Elevator(void)
 {
 	int area1num, area2num, modelnum, i, j, k, l, n, p;
 	float lip, height, speed;
@@ -3153,7 +3153,7 @@ void AAS_Reachability_Elevator(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-aas_lreachability_t *AAS_FindFaceReachabilities(vec3_t *facepoints, int numpoints, aas_plane_t *plane, int towardsface)
+static aas_lreachability_t *AAS_FindFaceReachabilities(vec3_t *facepoints, int numpoints, aas_plane_t *plane, int towardsface)
 {
 	int i, j, k, l;
 	int facenum, edgenum, bestfacenum;
@@ -3278,7 +3278,7 @@ aas_lreachability_t *AAS_FindFaceReachabilities(vec3_t *facepoints, int numpoint
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_Reachability_FuncBobbing(void)
+static void AAS_Reachability_FuncBobbing(void)
 {
 	int ent, spawnflags, modelnum, axis;
 	int i, numareas, areas[10];
@@ -3491,7 +3491,7 @@ void AAS_Reachability_FuncBobbing(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_Reachability_JumpPad(void)
+static void AAS_Reachability_JumpPad(void)
 {
 	int face2num, i, ret, area2num, visualize, ent, bot_visualizejumppads;
 	//int modelnum, ent2;
@@ -3786,7 +3786,7 @@ void AAS_Reachability_JumpPad(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_Reachability_Grapple(int area1num, int area2num)
+static int AAS_Reachability_Grapple(int area1num, int area2num)
 {
 	int face2num, i, j, areanum, numareas, areas[20];
 	float mingrappleangle, z, hordist;
@@ -3927,7 +3927,7 @@ int AAS_Reachability_Grapple(int area1num, int area2num)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_SetWeaponJumpAreaFlags(void)
+static void AAS_SetWeaponJumpAreaFlags(void)
 {
 	int ent, i;
 	vec3_t mins = {-15, -15, -15}, maxs = {15, 15, 15};
@@ -4125,7 +4125,7 @@ int AAS_Reachability_WeaponJump(int area1num, int area2num)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_Reachability_WalkOffLedge(int areanum)
+static void AAS_Reachability_WalkOffLedge(int areanum)
 {
 	int i, j, k, l, m, n, p, areas[10], numareas;
 	int face1num, face2num, face3num, edge1num, edge2num, edge3num;
@@ -4306,7 +4306,7 @@ void AAS_Reachability_WalkOffLedge(int areanum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_StoreReachability(void)
+static void AAS_StoreReachability(void)
 {
 	int i;
 	aas_areasettings_t *areasettings;

--- a/code/botlib/be_aas_reach.h
+++ b/code/botlib/be_aas_reach.h
@@ -60,8 +60,6 @@ int AAS_AreaLava(int areanum);
 int AAS_AreaSlime(int areanum);
 //returns true if the area has one or more ground faces
 int AAS_AreaGrounded(int areanum);
-//returns true if the area has one or more ladder faces
-int AAS_AreaLadder(int areanum);
 //returns true if the area is a jump pad
 int AAS_AreaJumpPad(int areanum);
 //returns true if the area is donotenter

--- a/code/botlib/be_aas_route.c
+++ b/code/botlib/be_aas_route.c
@@ -132,7 +132,7 @@ static ID_INLINE int AAS_ClusterAreaNum(int cluster, int areanum)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_InitTravelFlagFromType(void)
+static void AAS_InitTravelFlagFromType(void)
 {
 	int i;
 
@@ -197,7 +197,7 @@ int AAS_TravelFlagForType(int traveltype)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_UnlinkCache(aas_routingcache_t *cache)
+static void AAS_UnlinkCache(aas_routingcache_t *cache)
 {
 	if (cache->time_next) cache->time_next->time_prev = cache->time_prev;
 	else aasworld.newestcache = cache->time_prev;
@@ -212,7 +212,7 @@ void AAS_UnlinkCache(aas_routingcache_t *cache)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_LinkCache(aas_routingcache_t *cache)
+static void AAS_LinkCache(aas_routingcache_t *cache)
 {
 	if (aasworld.newestcache)
 	{
@@ -245,7 +245,7 @@ void AAS_FreeRoutingCache(aas_routingcache_t *cache)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_RemoveRoutingCacheInCluster( int clusternum )
+static void AAS_RemoveRoutingCacheInCluster( int clusternum )
 {
 	int i;
 	aas_routingcache_t *cache, *nextcache;
@@ -270,7 +270,7 @@ void AAS_RemoveRoutingCacheInCluster( int clusternum )
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_RemoveRoutingCacheUsingArea( int areanum )
+static void AAS_RemoveRoutingCacheUsingArea( int areanum )
 {
 	int i, clusternum;
 	aas_routingcache_t *cache, *nextcache;
@@ -349,7 +349,7 @@ static ID_INLINE float AAS_RoutingTime(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_GetAreaContentsTravelFlags(int areanum)
+static int AAS_GetAreaContentsTravelFlags(int areanum)
 {
 	int contents, tfl;
 
@@ -399,7 +399,7 @@ int AAS_AreaContentsTravelFlags(int areanum)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_InitAreaContentsTravelFlags(void)
+static void AAS_InitAreaContentsTravelFlags(void)
 {
 	int i;
 
@@ -416,7 +416,7 @@ void AAS_InitAreaContentsTravelFlags(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_CreateReversedReachability(void)
+static void AAS_CreateReversedReachability(void)
 {
 	int i, n;
 	aas_reversedlink_t *revlink;
@@ -497,7 +497,7 @@ unsigned short int AAS_AreaTravelTime(int areanum, vec3_t start, vec3_t end)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_CalculateAreaTravelTimes(void)
+static void AAS_CalculateAreaTravelTimes(void)
 {
 	int i, l, n, size;
 	char *ptr;
@@ -566,7 +566,7 @@ void AAS_CalculateAreaTravelTimes(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_PortalMaxTravelTime(int portalnum)
+static int AAS_PortalMaxTravelTime(int portalnum)
 {
 	int l, n, t, maxt;
 	aas_portal_t *portal;
@@ -600,7 +600,7 @@ int AAS_PortalMaxTravelTime(int portalnum)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_InitPortalMaxTravelTimes(void)
+static void AAS_InitPortalMaxTravelTimes(void)
 {
 	int i;
 
@@ -695,7 +695,7 @@ int AAS_FreeOldestCache(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_FreeOldestCache(void)
+static int AAS_FreeOldestCache(void)
 {
 	int clusterareanum;
 	aas_routingcache_t *cache;
@@ -734,7 +734,7 @@ int AAS_FreeOldestCache(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-aas_routingcache_t *AAS_AllocRoutingCache(int numtraveltimes)
+static aas_routingcache_t *AAS_AllocRoutingCache(int numtraveltimes)
 {
 	aas_routingcache_t *cache;
 	int size;
@@ -758,7 +758,7 @@ aas_routingcache_t *AAS_AllocRoutingCache(int numtraveltimes)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_FreeAllClusterAreaCache(void)
+static void AAS_FreeAllClusterAreaCache(void)
 {
 	int i, j;
 	aas_routingcache_t *cache, *nextcache;
@@ -790,7 +790,7 @@ void AAS_FreeAllClusterAreaCache(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_InitClusterAreaCache(void)
+static void AAS_InitClusterAreaCache(void)
 {
 	int i, size;
 	char *ptr;
@@ -819,7 +819,7 @@ void AAS_InitClusterAreaCache(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_FreeAllPortalCache(void)
+static void AAS_FreeAllPortalCache(void)
 {
 	int i;
 	aas_routingcache_t *cache, *nextcache;
@@ -845,7 +845,7 @@ void AAS_FreeAllPortalCache(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_InitPortalCache(void)
+static void AAS_InitPortalCache(void)
 {
 	//
 	aasworld.portalcache = (aas_routingcache_t **) GetClearedMemory(
@@ -857,7 +857,7 @@ void AAS_InitPortalCache(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_InitRoutingUpdate(void)
+static void AAS_InitRoutingUpdate(void)
 {
 	int i, maxreachabilityareas;
 
@@ -1033,7 +1033,7 @@ void AAS_WriteRouteCache(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-aas_routingcache_t *AAS_ReadCache(fileHandle_t fp)
+static aas_routingcache_t *AAS_ReadCache(fileHandle_t fp)
 {
 	int size;
 	aas_routingcache_t *cache;
@@ -1052,7 +1052,7 @@ aas_routingcache_t *AAS_ReadCache(fileHandle_t fp)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_ReadRouteCache(void)
+static int AAS_ReadRouteCache(void)
 {
 	int i, clusterareanum;//, size;
 	fileHandle_t fp;
@@ -1145,7 +1145,7 @@ int AAS_ReadRouteCache(void)
 //===========================================================================
 #define MAX_REACHABILITYPASSAREAS		32
 
-void AAS_InitReachabilityAreas(void)
+static void AAS_InitReachabilityAreas(void)
 {
 	int i, j, numareas, areas[MAX_REACHABILITYPASSAREAS];
 	int numreachareas;
@@ -1290,7 +1290,7 @@ void AAS_FreeRoutingCaches(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_UpdateAreaRoutingCache(aas_routingcache_t *areacache)
+static void AAS_UpdateAreaRoutingCache(aas_routingcache_t *areacache)
 {
 	int i, nextareanum, cluster, badtravelflags, clusterareanum, linknum;
 	int numreachabilityareas;
@@ -1401,7 +1401,7 @@ void AAS_UpdateAreaRoutingCache(aas_routingcache_t *areacache)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-aas_routingcache_t *AAS_GetAreaRoutingCache(int clusternum, int areanum, int travelflags)
+static aas_routingcache_t *AAS_GetAreaRoutingCache(int clusternum, int areanum, int travelflags)
 {
 	int clusterareanum;
 	aas_routingcache_t *cache, *clustercache;
@@ -1447,7 +1447,7 @@ aas_routingcache_t *AAS_GetAreaRoutingCache(int clusternum, int areanum, int tra
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_UpdatePortalRoutingCache(aas_routingcache_t *portalcache)
+static void AAS_UpdatePortalRoutingCache(aas_routingcache_t *portalcache)
 {
 	int i, portalnum, clusterareanum, clusternum;
 	unsigned short int t;
@@ -1545,7 +1545,7 @@ void AAS_UpdatePortalRoutingCache(aas_routingcache_t *portalcache)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-aas_routingcache_t *AAS_GetPortalRoutingCache(int clusternum, int areanum, int travelflags)
+static aas_routingcache_t *AAS_GetPortalRoutingCache(int clusternum, int areanum, int travelflags)
 {
 	aas_routingcache_t *cache;
 
@@ -1587,7 +1587,7 @@ aas_routingcache_t *AAS_GetPortalRoutingCache(int clusternum, int areanum, int t
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_AreaRouteToGoalArea(int areanum, vec3_t origin, int goalareanum, int travelflags, int *traveltime, int *reachnum)
+static int AAS_AreaRouteToGoalArea(int areanum, vec3_t origin, int goalareanum, int travelflags, int *traveltime, int *reachnum)
 {
 	int clusternum, goalclusternum, portalnum, i, clusterareanum, bestreachnum;
 	unsigned short int t, besttime;
@@ -1793,7 +1793,7 @@ int AAS_AreaTravelTimeToGoalArea(int areanum, vec3_t origin, int goalareanum, in
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_AreaReachabilityToGoalArea(int areanum, vec3_t origin, int goalareanum, int travelflags)
+static int AAS_AreaReachabilityToGoalArea(int areanum, vec3_t origin, int goalareanum, int travelflags)
 {
 	int traveltime, reachnum = 0;
 
@@ -2066,7 +2066,7 @@ int AAS_RandomGoalArea(int areanum, int travelflags, int *goalareanum, vec3_t go
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_AreaVisible(int srcarea, int destarea)
+static int AAS_AreaVisible(int srcarea, int destarea)
 {
 	return qfalse;
 } //end of the function AAS_AreaVisible

--- a/code/botlib/be_aas_routealt.c
+++ b/code/botlib/be_aas_routealt.c
@@ -53,9 +53,9 @@ typedef struct midrangearea_s
 	unsigned short goaltime;
 } midrangearea_t;
 
-midrangearea_t *midrangeareas;
-int *clusterareas;
-int numclusterareas;
+static midrangearea_t *midrangeareas;
+static int *clusterareas;
+static int numclusterareas;
 
 //===========================================================================
 //
@@ -63,7 +63,7 @@ int numclusterareas;
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_AltRoutingFloodCluster_r(int areanum)
+static void AAS_AltRoutingFloodCluster_r(int areanum)
 {
 	int i, otherareanum;
 	aas_area_t *area;

--- a/code/botlib/be_aas_sample.c
+++ b/code/botlib/be_aas_sample.c
@@ -61,7 +61,7 @@ typedef struct aas_tracestack_s
 	int nodenum;		//node found after splitting with planenum
 } aas_tracestack_t;
 
-int numaaslinks;
+static int numaaslinks;
 
 //===========================================================================
 //
@@ -73,8 +73,8 @@ void AAS_PresenceTypeBoundingBox(int presencetype, vec3_t mins, vec3_t maxs)
 {
 	int index;
 	//bounding box size for each presence type
-	vec3_t boxmins[3] = {{0, 0, 0}, {-15, -15, -24}, {-15, -15, -24}};
-	vec3_t boxmaxs[3] = {{0, 0, 0}, { 15,  15,  32}, { 15,  15,   8}};
+	static vec3_t boxmins[3] = {{0, 0, 0}, {-15, -15, -24}, {-15, -15, -24}};
+	static vec3_t boxmaxs[3] = {{0, 0, 0}, { 15,  15,  32}, { 15,  15,   8}};
 
 	if (presencetype == PRESENCE_NORMAL) index = 1;
 	else if (presencetype == PRESENCE_CROUCH) index = 2;
@@ -168,7 +168,7 @@ aas_link_t *AAS_AllocAASLink(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AAS_DeAllocAASLink(aas_link_t *link)
+static void AAS_DeAllocAASLink(aas_link_t *link)
 {
 	if (aasworld.freelinks) aasworld.freelinks->prev_ent = link;
 	link->prev_ent = NULL;
@@ -402,7 +402,7 @@ vec_t AAS_BoxOriginDistanceFromPlane(vec3_t normal, vec3_t mins, vec3_t maxs, in
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-qboolean AAS_AreaEntityCollision(int areanum, vec3_t start, vec3_t end,
+static qboolean AAS_AreaEntityCollision(int areanum, vec3_t start, vec3_t end,
 										int presencetype, int passent, aas_trace_t *trace)
 {
 	int collision;
@@ -922,7 +922,7 @@ int AAS_TraceAreas(vec3_t start, vec3_t end, int *areas, vec3_t *points, int max
 // Returns:					qtrue if the point is within the face boundaries
 // Changes Globals:		-
 //===========================================================================
-qboolean AAS_InsideFace(aas_face_t *face, vec3_t pnormal, vec3_t point, float epsilon)
+static qboolean AAS_InsideFace(aas_face_t *face, vec3_t pnormal, vec3_t point, float epsilon)
 {
 	int i, firstvertex, edgenum;
 	vec3_t v0;
@@ -1123,7 +1123,7 @@ aas_face_t *AAS_TraceEndFace(aas_trace_t *trace)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_BoxOnPlaneSide2(vec3_t absmins, vec3_t absmaxs, aas_plane_t *p)
+static int AAS_BoxOnPlaneSide2(vec3_t absmins, vec3_t absmaxs, aas_plane_t *p)
 {
 	int i, sides;
 	float dist1, dist2;

--- a/code/botlib/be_aas_sample.h
+++ b/code/botlib/be_aas_sample.h
@@ -40,7 +40,6 @@ aas_plane_t *AAS_PlaneFromNum(int planenum);
 aas_link_t *AAS_AASLinkEntity(vec3_t absmins, vec3_t absmaxs, int entnum);
 aas_link_t *AAS_LinkEntityClientBBox(vec3_t absmins, vec3_t absmaxs, int entnum, int presencetype);
 qboolean AAS_PointInsideFace(int facenum, vec3_t point, float epsilon);
-qboolean AAS_InsideFace(aas_face_t *face, vec3_t pnormal, vec3_t point, float epsilon);
 void AAS_UnlinkFromAreas(aas_link_t *areas);
 #endif //AASINTERN
 

--- a/code/botlib/be_ai_char.c
+++ b/code/botlib/be_ai_char.c
@@ -450,7 +450,7 @@ static int BotFindCachedCharacter(const char *charfile, float skill)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotLoadCachedCharacter(const char *charfile, float skill, int reload)
+static int BotLoadCachedCharacter(const char *charfile, float skill, int reload)
 {
 	int handle, cachedhandle, intskill;
 	bot_character_t *ch = NULL;
@@ -712,7 +712,7 @@ int BotLoadCharacter(const char *charfile, float skill)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int CheckCharacteristicIndex(int character, int index)
+static int CheckCharacteristicIndex(int character, int index)
 {
 	bot_character_t *ch;
 

--- a/code/botlib/be_ai_chat.c
+++ b/code/botlib/be_ai_chat.c
@@ -195,20 +195,20 @@ typedef struct {
 	char		chatname[MAX_QPATH];
 } bot_ichatdata_t;
 
-bot_ichatdata_t	*ichatdata[MAX_CLIENTS];
+static bot_ichatdata_t	*ichatdata[MAX_CLIENTS];
 
-bot_chatstate_t *botchatstates[MAX_CLIENTS+1];
+static bot_chatstate_t *botchatstates[MAX_CLIENTS+1];
 //console message heap
-bot_consolemessage_t *consolemessageheap = NULL;
-bot_consolemessage_t *freeconsolemessages = NULL;
+static bot_consolemessage_t *consolemessageheap = NULL;
+static bot_consolemessage_t *freeconsolemessages = NULL;
 //list with match strings
-bot_matchtemplate_t *matchtemplates = NULL;
+static bot_matchtemplate_t *matchtemplates = NULL;
 //list with synonyms
-bot_synonymlist_t *synonyms = NULL;
+static bot_synonymlist_t *synonyms = NULL;
 //list with random strings
-bot_randomlist_t *randomstrings = NULL;
+static bot_randomlist_t *randomstrings = NULL;
 //reply chats
-bot_replychat_t *replychats = NULL;
+static bot_replychat_t *replychats = NULL;
 
 //========================================================================
 //
@@ -216,7 +216,7 @@ bot_replychat_t *replychats = NULL;
 // Returns:					-
 // Changes Globals:		-
 //========================================================================
-bot_chatstate_t *BotChatStateFromHandle(int handle)
+static bot_chatstate_t *BotChatStateFromHandle(int handle)
 {
 	if (handle <= 0 || handle > MAX_CLIENTS)
 	{
@@ -237,7 +237,7 @@ bot_chatstate_t *BotChatStateFromHandle(int handle)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void InitConsoleMessageHeap(void)
+static void InitConsoleMessageHeap(void)
 {
 	int i, max_messages;
 
@@ -265,7 +265,7 @@ void InitConsoleMessageHeap(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_consolemessage_t *AllocConsoleMessage(void)
+static bot_consolemessage_t *AllocConsoleMessage(void)
 {
 	bot_consolemessage_t *message;
 	message = freeconsolemessages;
@@ -280,7 +280,7 @@ bot_consolemessage_t *AllocConsoleMessage(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void FreeConsoleMessage(bot_consolemessage_t *message)
+static void FreeConsoleMessage(bot_consolemessage_t *message)
 {
 	if (freeconsolemessages) freeconsolemessages->prev = message;
 	message->prev = NULL;
@@ -411,7 +411,7 @@ int BotNumConsoleMessages(int chatstate)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int IsWhiteSpace(char c)
+static int IsWhiteSpace(char c)
 {
 	if ((c >= 'a' && c <= 'z')
 		|| (c >= 'A' && c <= 'Z')
@@ -431,7 +431,7 @@ int IsWhiteSpace(char c)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void BotRemoveTildes(char *message)
+static void BotRemoveTildes(char *message)
 {
 	int i;
 
@@ -611,7 +611,7 @@ void BotDumpSynonymList(bot_synonymlist_t *synlist)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_synonymlist_t *BotLoadSynonyms( const char *filename )
+static bot_synonymlist_t *BotLoadSynonyms( const char *filename )
 {
 	int pass, size, contextlevel, numsynonyms;
 	unsigned long int context, contextstack[32];
@@ -994,7 +994,7 @@ void BotDumpRandomStringList(bot_randomlist_t *randomlist)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_randomlist_t *BotLoadRandomStrings( const char *filename )
+static bot_randomlist_t *BotLoadRandomStrings( const char *filename )
 {
 	int pass, size;
 	char *ptr = NULL, chatmessagestring[MAX_MESSAGE_SIZE];
@@ -1166,7 +1166,7 @@ void BotDumpMatchTemplates(bot_matchtemplate_t *matches)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotFreeMatchPieces(bot_matchpiece_t *matchpieces)
+static void BotFreeMatchPieces(bot_matchpiece_t *matchpieces)
 {
 	bot_matchpiece_t *mp, *nextmp;
 	bot_matchstring_t *ms, *nextms;
@@ -1191,7 +1191,7 @@ void BotFreeMatchPieces(bot_matchpiece_t *matchpieces)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_matchpiece_t *BotLoadMatchPieces(source_t *source, char *endtoken)
+static bot_matchpiece_t *BotLoadMatchPieces(source_t *source, char *endtoken)
 {
 	int lastwasvariable, emptystring;
 	token_t token;
@@ -1293,7 +1293,7 @@ bot_matchpiece_t *BotLoadMatchPieces(source_t *source, char *endtoken)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotFreeMatchTemplates(bot_matchtemplate_t *mt)
+static void BotFreeMatchTemplates(bot_matchtemplate_t *mt)
 {
 	bot_matchtemplate_t *nextmt;
 
@@ -1310,7 +1310,7 @@ void BotFreeMatchTemplates(bot_matchtemplate_t *mt)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_matchtemplate_t *BotLoadMatchTemplates( const char *matchfile )
+static bot_matchtemplate_t *BotLoadMatchTemplates( const char *matchfile )
 {
 	source_t *source;
 	token_t token;
@@ -1409,7 +1409,7 @@ bot_matchtemplate_t *BotLoadMatchTemplates( const char *matchfile )
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int StringsMatch(bot_matchpiece_t *pieces, bot_match_t *match)
+static int StringsMatch(bot_matchpiece_t *pieces, bot_match_t *match)
 {
 	int lastvariable, index;
 	char *strptr, *newstrptr;
@@ -1630,7 +1630,7 @@ static bot_stringlist_t *BotCheckChatMessageIntegrety(char *message, bot_stringl
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotCheckInitialChatIntegrety(bot_chat_t *chat)
+static void BotCheckInitialChatIntegrety(bot_chat_t *chat)
 {
 	bot_chattype_t *t;
 	bot_chatmessage_t *cm;
@@ -1656,7 +1656,7 @@ void BotCheckInitialChatIntegrety(bot_chat_t *chat)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotCheckReplyChatIntegrety(bot_replychat_t *replychat)
+static void BotCheckReplyChatIntegrety(bot_replychat_t *replychat)
 {
 	bot_replychat_t *rp;
 	bot_chatmessage_t *cm;
@@ -1737,7 +1737,7 @@ void BotDumpReplyChat(bot_replychat_t *replychat)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotFreeReplyChat(bot_replychat_t *replychat)
+static void BotFreeReplyChat(bot_replychat_t *replychat)
 {
 	bot_replychat_t *rp, *nextrp;
 	bot_replychatkey_t *key, *nextkey;
@@ -1767,7 +1767,7 @@ void BotFreeReplyChat(bot_replychat_t *replychat)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void BotCheckValidReplyChatKeySet(source_t *source, bot_replychatkey_t *keys)
+static void BotCheckValidReplyChatKeySet(source_t *source, bot_replychatkey_t *keys)
 {
 	int allprefixed, hasvariableskey, hasstringkey;
 	bot_matchpiece_t *m;
@@ -1874,7 +1874,7 @@ void BotCheckValidReplyChatKeySet(source_t *source, bot_replychatkey_t *keys)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-bot_replychat_t *BotLoadReplyChat( const char *filename )
+static bot_replychat_t *BotLoadReplyChat( const char *filename )
 {
 	char chatmessagestring[MAX_MESSAGE_SIZE];
 	char namebuffer[MAX_MESSAGE_SIZE];
@@ -2059,7 +2059,7 @@ void BotDumpInitialChat(bot_chat_t *chat)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_chat_t *BotLoadInitialChat(char *chatfile, char *chatname)
+static bot_chat_t *BotLoadInitialChat(char *chatfile, char *chatname)
 {
 	int pass, foundchat, indent, size;
 	char *ptr = NULL;
@@ -2234,7 +2234,7 @@ bot_chat_t *BotLoadInitialChat(char *chatfile, char *chatname)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void BotFreeChatFile(int chatstate)
+static void BotFreeChatFile(int chatstate)
 {
 	bot_chatstate_t *cs;
 
@@ -2460,7 +2460,7 @@ static void BotConstructChatMessage(bot_chatstate_t *chatstate, const char *mess
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-char *BotChooseInitialChatMessage(bot_chatstate_t *cs, char *type)
+static char *BotChooseInitialChatMessage(bot_chatstate_t *cs, char *type)
 {
 	int n, numchatmessages;
 	float besttime;

--- a/code/botlib/be_ai_gen.c
+++ b/code/botlib/be_ai_gen.c
@@ -49,7 +49,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int GeneticSelection(int numranks, float *rankings)
+static int GeneticSelection(int numranks, float *rankings)
 {
 	float sum;
 	int i, index;

--- a/code/botlib/be_ai_goal.c
+++ b/code/botlib/be_ai_goal.c
@@ -136,7 +136,7 @@ typedef struct iteminfo_s
 
 #define ITEMINFO_OFS(x)	(size_t)&(((iteminfo_t *)0)->x)
 
-fielddef_t iteminfo_fields[] =
+static fielddef_t iteminfo_fields[] =
 {
 {"name", ITEMINFO_OFS(name), FT_STRING},
 {"model", ITEMINFO_OFS(model), FT_STRING},
@@ -149,7 +149,7 @@ fielddef_t iteminfo_fields[] =
 {NULL, 0, 0}
 };
 
-structdef_t iteminfo_struct =
+static structdef_t iteminfo_struct =
 {
 	sizeof(iteminfo_t), iteminfo_fields
 };
@@ -176,22 +176,22 @@ typedef struct bot_goalstate_s
 	float avoidgoaltimes[MAX_AVOIDGOALS];		//times to avoid the goals
 } bot_goalstate_t;
 
-bot_goalstate_t *botgoalstates[MAX_CLIENTS + 1]; // FIXME: init?
+static bot_goalstate_t *botgoalstates[MAX_CLIENTS + 1]; // FIXME: init?
 //item configuration
-itemconfig_t *itemconfig = NULL;
+static itemconfig_t *itemconfig = NULL;
 //level items
-levelitem_t *levelitemheap = NULL;
-levelitem_t *freelevelitems = NULL;
-levelitem_t *levelitems = NULL;
-int numlevelitems = 0;
+static levelitem_t *levelitemheap = NULL;
+static levelitem_t *freelevelitems = NULL;
+static levelitem_t *levelitems = NULL;
+static int numlevelitems = 0;
 //map locations
-maplocation_t *maplocations = NULL;
+static maplocation_t *maplocations = NULL;
 //camp spots
-campspot_t *campspots = NULL;
+static campspot_t *campspots = NULL;
 //the game type
-int g_gametype = 0;
+static int g_gametype = 0;
 //additional dropped item weight
-libvar_t *droppedweight = NULL;
+static libvar_t *droppedweight = NULL;
 
 //========================================================================
 //
@@ -269,7 +269,7 @@ void BotMutateGoalFuzzyLogic(int goalstate, float range)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-itemconfig_t *LoadItemConfig( const char *filename )
+static itemconfig_t *LoadItemConfig( const char *filename )
 {
 	int max_iteminfo;
 	token_t token;
@@ -350,7 +350,7 @@ itemconfig_t *LoadItemConfig( const char *filename )
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int *ItemWeightIndex(weightconfig_t *iwc, itemconfig_t *ic)
+static int *ItemWeightIndex(weightconfig_t *iwc, itemconfig_t *ic)
 {
 	int *index, i;
 
@@ -373,7 +373,7 @@ int *ItemWeightIndex(weightconfig_t *iwc, itemconfig_t *ic)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void InitLevelItemHeap(void)
+static void InitLevelItemHeap(void)
 {
 	int i, max_levelitems;
 
@@ -396,7 +396,7 @@ void InitLevelItemHeap(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-levelitem_t *AllocLevelItem(void)
+static levelitem_t *AllocLevelItem(void)
 {
 	levelitem_t *li;
 
@@ -417,7 +417,7 @@ levelitem_t *AllocLevelItem(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void FreeLevelItem(levelitem_t *li)
+static void FreeLevelItem(levelitem_t *li)
 {
 	li->next = freelevelitems;
 	freelevelitems = li;
@@ -428,7 +428,7 @@ void FreeLevelItem(levelitem_t *li)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void AddLevelItemToList(levelitem_t *li)
+static void AddLevelItemToList(levelitem_t *li)
 {
 	if (levelitems) levelitems->prev = li;
 	li->prev = NULL;
@@ -441,7 +441,7 @@ void AddLevelItemToList(levelitem_t *li)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void RemoveLevelItemFromList(levelitem_t *li)
+static void RemoveLevelItemFromList(levelitem_t *li)
 {
 	if (li->prev) li->prev->next = li->next;
 	else levelitems = li->next;
@@ -453,7 +453,7 @@ void RemoveLevelItemFromList(levelitem_t *li)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void BotFreeInfoEntities(void)
+static void BotFreeInfoEntities(void)
 {
 	maplocation_t *ml, *nextml;
 	campspot_t *cs, *nextcs;
@@ -477,7 +477,7 @@ void BotFreeInfoEntities(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void BotInitInfoEntities(void)
+static void BotInitInfoEntities(void)
 {
 	char classname[MAX_EPAIRKEY];
 	maplocation_t *ml;
@@ -741,7 +741,7 @@ void BotDumpAvoidGoals(int goalstate)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotAddToAvoidGoals(bot_goalstate_t *gs, int number, float avoidtime)
+static void BotAddToAvoidGoals(bot_goalstate_t *gs, int number, float avoidtime)
 {
 	int i;
 

--- a/code/botlib/be_ai_move.c
+++ b/code/botlib/be_ai_move.c
@@ -101,20 +101,20 @@ typedef struct bot_movestate_s
 #define MODELTYPE_FUNC_DOOR		3
 #define MODELTYPE_FUNC_STATIC	4
 
-libvar_t *sv_maxstep;
-libvar_t *sv_maxbarrier;
-libvar_t *sv_gravity;
-libvar_t *weapindex_rocketlauncher;
-libvar_t *weapindex_bfg10k;
-libvar_t *weapindex_grapple;
-libvar_t *entitytypemissile;
-libvar_t *offhandgrapple;
-libvar_t *cmd_grappleoff;
-libvar_t *cmd_grappleon;
+static libvar_t *sv_maxstep;
+static libvar_t *sv_maxbarrier;
+static libvar_t *sv_gravity;
+static libvar_t *weapindex_rocketlauncher;
+static libvar_t *weapindex_bfg10k;
+static libvar_t *weapindex_grapple;
+static libvar_t *entitytypemissile;
+static libvar_t *offhandgrapple;
+static libvar_t *cmd_grappleoff;
+static libvar_t *cmd_grappleon;
 //type of model, func_plat or func_bobbing
-int modeltypes[MAX_MODELS];
+static int modeltypes[MAX_MODELS];
 
-bot_movestate_t *botmovestates[MAX_CLIENTS+1];
+static bot_movestate_t *botmovestates[MAX_CLIENTS+1];
 
 //========================================================================
 //
@@ -163,7 +163,7 @@ void BotFreeMoveState(int handle)
 // Returns:					-
 // Changes Globals:		-
 //========================================================================
-bot_movestate_t *BotMoveStateFromHandle(int handle)
+static bot_movestate_t *BotMoveStateFromHandle(int handle)
 {
 	if (handle <= 0 || handle > MAX_CLIENTS)
 	{
@@ -437,7 +437,7 @@ int BotReachabilityArea(vec3_t origin, int testground)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotOnMover(vec3_t origin, int entnum, aas_reachability_t *reach)
+static int BotOnMover(vec3_t origin, int entnum, aas_reachability_t *reach)
 {
 	int i, modelnum;
 	vec3_t mins, maxs, modelorigin, org, end;
@@ -483,7 +483,7 @@ int BotOnMover(vec3_t origin, int entnum, aas_reachability_t *reach)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int MoverDown(aas_reachability_t *reach)
+static int MoverDown(aas_reachability_t *reach)
 {
 	int modelnum;
 	vec3_t mins, maxs, origin;
@@ -544,7 +544,7 @@ void BotSetBrushModelTypes(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotOnTopOfEntity(bot_movestate_t *ms)
+static int BotOnTopOfEntity(bot_movestate_t *ms)
 {
 	vec3_t mins, maxs, end, up = {0, 0, 1};
 	bsp_trace_t trace;
@@ -564,7 +564,7 @@ int BotOnTopOfEntity(bot_movestate_t *ms)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotValidTravel(vec3_t origin, aas_reachability_t *reach, int travelflags)
+static int BotValidTravel(vec3_t origin, aas_reachability_t *reach, int travelflags)
 {
 	//if the reachability uses an unwanted travel type
 	if (AAS_TravelFlagForType(reach->traveltype) & ~travelflags) return qfalse;
@@ -578,7 +578,7 @@ int BotValidTravel(vec3_t origin, aas_reachability_t *reach, int travelflags)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotAddToAvoidReach(bot_movestate_t *ms, int number, float avoidtime)
+static void BotAddToAvoidReach(bot_movestate_t *ms, int number, float avoidtime)
 {
 	int i;
 
@@ -610,7 +610,7 @@ void BotAddToAvoidReach(bot_movestate_t *ms, int number, float avoidtime)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-float DistanceFromLineSquared(vec3_t p, vec3_t lp1, vec3_t lp2)
+static float DistanceFromLineSquared(vec3_t p, vec3_t lp1, vec3_t lp2)
 {
 	vec3_t proj, dir;
 	int j;
@@ -648,7 +648,7 @@ float VectorDistanceSquared(vec3_t p1, vec3_t p2)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotAvoidSpots(vec3_t origin, aas_reachability_t *reach, bot_avoidspot_t *avoidspots, int numavoidspots)
+static int BotAvoidSpots(vec3_t origin, aas_reachability_t *reach, bot_avoidspot_t *avoidspots, int numavoidspots)
 {
 	int checkbetween, i, type;
 	float squareddist, squaredradius;
@@ -816,7 +816,7 @@ int BotGetReachabilityToGoal(vec3_t origin, int areanum,
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int BotAddToTarget(vec3_t start, vec3_t end, float maxdist, float *dist, vec3_t target)
+static int BotAddToTarget(vec3_t start, vec3_t end, float maxdist, float *dist, vec3_t target)
 {
 	vec3_t dir;
 	float curdist;
@@ -891,7 +891,7 @@ int BotMovementViewTarget(int movestate, bot_goal_t *goal, int travelflags, floa
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotVisible(int ent, vec3_t eye, vec3_t target)
+static int BotVisible(int ent, vec3_t eye, vec3_t target)
 {
 	bsp_trace_t trace;
 
@@ -968,7 +968,7 @@ int BotPredictVisiblePosition(vec3_t origin, int areanum, bot_goal_t *goal, int 
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void MoverBottomCenter(aas_reachability_t *reach, vec3_t bottomcenter)
+static void MoverBottomCenter(aas_reachability_t *reach, vec3_t bottomcenter)
 {
 	int modelnum;
 	vec3_t mins, maxs, origin, mids;
@@ -993,7 +993,7 @@ void MoverBottomCenter(aas_reachability_t *reach, vec3_t bottomcenter)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-float BotGapDistance(vec3_t origin, vec3_t hordir, int entnum)
+static float BotGapDistance(vec3_t origin, vec3_t hordir, int entnum)
 {
 	int dist;
 	float startz;
@@ -1093,7 +1093,7 @@ int BotCheckBarrierJump(bot_movestate_t *ms, vec3_t dir, float speed)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotSwimInDirection(bot_movestate_t *ms, vec3_t dir, float speed, int type)
+static int BotSwimInDirection(bot_movestate_t *ms, vec3_t dir, float speed, int type)
 {
 	vec3_t normdir;
 
@@ -1108,7 +1108,7 @@ int BotSwimInDirection(bot_movestate_t *ms, vec3_t dir, float speed, int type)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotWalkInDirection(bot_movestate_t *ms, vec3_t dir, float speed, int type)
+static int BotWalkInDirection(bot_movestate_t *ms, vec3_t dir, float speed, int type)
 {
 	vec3_t hordir, cmdmove, velocity, tmpdir, origin;
 	int presencetype, maxframes, cmdframes, stopevent;
@@ -1324,7 +1324,7 @@ void BotCheckBlocked(bot_movestate_t *ms, vec3_t dir, int checkbottom, bot_mover
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_Walk(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Walk(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	float dist, speed;
 	vec3_t hordir;
@@ -1414,7 +1414,7 @@ bot_moveresult_t BotFinishTravel_Walk(bot_movestate_t *ms, aas_reachability_t *r
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_Crouch(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Crouch(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	float speed;
 	vec3_t hordir;
@@ -1443,7 +1443,7 @@ bot_moveresult_t BotTravel_Crouch(bot_movestate_t *ms, aas_reachability_t *reach
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_BarrierJump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_BarrierJump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	float dist, speed;
 	vec3_t hordir;
@@ -1477,7 +1477,7 @@ bot_moveresult_t BotTravel_BarrierJump(bot_movestate_t *ms, aas_reachability_t *
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotFinishTravel_BarrierJump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotFinishTravel_BarrierJump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir;
 	bot_moveresult_t_cleared( result );
@@ -1503,7 +1503,7 @@ bot_moveresult_t BotFinishTravel_BarrierJump(bot_movestate_t *ms, aas_reachabili
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_Swim(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Swim(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t dir;
 	bot_moveresult_t_cleared( result );
@@ -1528,7 +1528,7 @@ bot_moveresult_t BotTravel_Swim(bot_movestate_t *ms, aas_reachability_t *reach)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_WaterJump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_WaterJump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t dir, hordir;
 	float dist;
@@ -1561,7 +1561,7 @@ bot_moveresult_t BotTravel_WaterJump(bot_movestate_t *ms, aas_reachability_t *re
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotFinishTravel_WaterJump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotFinishTravel_WaterJump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t dir, pnt;
 	bot_moveresult_t_cleared( result );
@@ -1657,7 +1657,7 @@ bot_moveresult_t BotTravel_WalkOffLedge(bot_movestate_t *ms, aas_reachability_t 
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotAirControl(vec3_t origin, vec3_t velocity, vec3_t goal, vec3_t dir, float *speed)
+static int BotAirControl(vec3_t origin, vec3_t velocity, vec3_t goal, vec3_t dir, float *speed)
 {
 	vec3_t org, vel;
 	float dist;
@@ -1694,7 +1694,7 @@ int BotAirControl(vec3_t origin, vec3_t velocity, vec3_t goal, vec3_t dir, float
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotFinishTravel_WalkOffLedge(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotFinishTravel_WalkOffLedge(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t dir, hordir, end, v;
 	float dist, speed;
@@ -1851,7 +1851,7 @@ bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 	return result;
 } //end of the function BotTravel_Jump*/
 //*
-bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir, dir1, dir2, start, end, runstart;
 //	vec3_t runstart, dir1, dir2, hordir;
@@ -1922,7 +1922,7 @@ bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotFinishTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotFinishTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir, hordir2;
 	float speed, dist;
@@ -1956,7 +1956,7 @@ bot_moveresult_t BotFinishTravel_Jump(bot_movestate_t *ms, aas_reachability_t *r
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_Ladder(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Ladder(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	//float dist, speed;
 	vec3_t dir, viewdir;//, hordir;
@@ -2011,7 +2011,7 @@ bot_moveresult_t BotTravel_Ladder(bot_movestate_t *ms, aas_reachability_t *reach
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_Teleport(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Teleport(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir;
 	float dist;
@@ -2041,7 +2041,7 @@ bot_moveresult_t BotTravel_Teleport(bot_movestate_t *ms, aas_reachability_t *rea
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_Elevator(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Elevator(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t dir, dir1, dir2, hordir, bottomcenter;
 	float dist, dist1, dist2, speed;
@@ -2191,7 +2191,7 @@ bot_moveresult_t BotTravel_Elevator(bot_movestate_t *ms, aas_reachability_t *rea
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotFinishTravel_Elevator(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotFinishTravel_Elevator(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t bottomcenter, bottomdir, topdir;
 	bot_moveresult_t_cleared( result );
@@ -2220,7 +2220,7 @@ bot_moveresult_t BotFinishTravel_Elevator(bot_movestate_t *ms, aas_reachability_
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void BotFuncBobStartEnd(aas_reachability_t *reach, vec3_t start, vec3_t end, vec3_t origin)
+static void BotFuncBobStartEnd(aas_reachability_t *reach, vec3_t start, vec3_t end, vec3_t origin)
 {
 	int spawnflags, modelnum;
 	vec3_t mins, maxs, mid, angles = {0, 0, 0};
@@ -2278,7 +2278,7 @@ void BotFuncBobStartEnd(aas_reachability_t *reach, vec3_t start, vec3_t end, vec
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_FuncBobbing(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_FuncBobbing(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t dir, dir1, dir2, hordir, bottomcenter, bob_start, bob_end, bob_origin;
 	float dist, dist1, dist2, speed;
@@ -2435,7 +2435,7 @@ bot_moveresult_t BotTravel_FuncBobbing(bot_movestate_t *ms, aas_reachability_t *
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotFinishTravel_FuncBobbing(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotFinishTravel_FuncBobbing(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t bob_origin, bob_start, bob_end, dir, hordir, bottomcenter;
 	bot_moveresult_t_cleared( result );
@@ -2489,7 +2489,7 @@ bot_moveresult_t BotFinishTravel_FuncBobbing(bot_movestate_t *ms, aas_reachabili
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int GrappleState(bot_movestate_t *ms, aas_reachability_t *reach)
+static int GrappleState(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	int i;
 	aas_entityinfo_t entinfo;
@@ -2519,7 +2519,7 @@ int GrappleState(bot_movestate_t *ms, aas_reachability_t *reach)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotResetGrapple(bot_movestate_t *ms)
+static void BotResetGrapple(bot_movestate_t *ms)
 {
 	aas_reachability_t reach;
 
@@ -2545,7 +2545,7 @@ void BotResetGrapple(bot_movestate_t *ms)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_Grapple(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Grapple(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	bot_moveresult_t_cleared( result );
 	float dist, speed;
@@ -2698,7 +2698,7 @@ bot_moveresult_t BotTravel_Grapple(bot_movestate_t *ms, aas_reachability_t *reac
 // Returns:					-
 // Changes Globals:			-
 //===========================================================================
-bot_moveresult_t BotTravel_RocketJump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_RocketJump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir;
 	float dist, speed;
@@ -2762,7 +2762,7 @@ bot_moveresult_t BotTravel_RocketJump(bot_movestate_t *ms, aas_reachability_t *r
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_BFGJump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_BFGJump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir;
 	float dist, speed;
@@ -2822,7 +2822,7 @@ bot_moveresult_t BotTravel_BFGJump(bot_movestate_t *ms, aas_reachability_t *reac
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotFinishTravel_WeaponJump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotFinishTravel_WeaponJump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir;
 	float speed;
@@ -2861,7 +2861,7 @@ bot_moveresult_t BotFinishTravel_WeaponJump(bot_movestate_t *ms, aas_reachabilit
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_JumpPad(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_JumpPad(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir;
 	bot_moveresult_t_cleared( result );
@@ -2884,7 +2884,7 @@ bot_moveresult_t BotTravel_JumpPad(bot_movestate_t *ms, aas_reachability_t *reac
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotFinishTravel_JumpPad(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotFinishTravel_JumpPad(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	float speed;
 	vec3_t hordir;
@@ -2912,7 +2912,7 @@ bot_moveresult_t BotFinishTravel_JumpPad(bot_movestate_t *ms, aas_reachability_t
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int BotReachabilityTime(aas_reachability_t *reach)
+static int BotReachabilityTime(aas_reachability_t *reach)
 {
 	switch(reach->traveltype & TRAVELTYPE_MASK)
 	{
@@ -2944,7 +2944,7 @@ int BotReachabilityTime(aas_reachability_t *reach)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotMoveInGoalArea(bot_movestate_t *ms, bot_goal_t *goal)
+static bot_moveresult_t BotMoveInGoalArea(bot_movestate_t *ms, bot_goal_t *goal)
 {
 	bot_moveresult_t_cleared( result );
 	vec3_t dir;

--- a/code/botlib/be_ai_weap.c
+++ b/code/botlib/be_ai_weap.c
@@ -134,7 +134,7 @@ static weaponconfig_t *weaponconfig;
 // Returns:					-
 // Changes Globals:		-
 //========================================================================
-int BotValidWeaponNumber(int weaponnum)
+static int BotValidWeaponNumber(int weaponnum)
 {
 	if (weaponnum <= 0 || weaponnum > weaponconfig->numweapons)
 	{
@@ -149,7 +149,7 @@ int BotValidWeaponNumber(int weaponnum)
 // Returns:					-
 // Changes Globals:		-
 //========================================================================
-bot_weaponstate_t *BotWeaponStateFromHandle(int handle)
+static bot_weaponstate_t *BotWeaponStateFromHandle(int handle)
 {
 	if (handle <= 0 || handle > MAX_CLIENTS)
 	{
@@ -170,7 +170,7 @@ bot_weaponstate_t *BotWeaponStateFromHandle(int handle)
 // Changes Globals:		-
 //===========================================================================
 #ifdef DEBUG_AI_WEAP
-void DumpWeaponConfig(weaponconfig_t *wc)
+static void DumpWeaponConfig(weaponconfig_t *wc)
 {
 	FILE *fp;
 	int i;
@@ -195,7 +195,7 @@ void DumpWeaponConfig(weaponconfig_t *wc)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-weaponconfig_t *LoadWeaponConfig(const char *filename)
+static weaponconfig_t *LoadWeaponConfig(const char *filename)
 {
 	int max_weaponinfo, max_projectileinfo;
 	token_t token;
@@ -327,7 +327,7 @@ weaponconfig_t *LoadWeaponConfig(const char *filename)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int *WeaponWeightIndex(weightconfig_t *wwc, weaponconfig_t *wc)
+static int *WeaponWeightIndex(weightconfig_t *wwc, weaponconfig_t *wc)
 {
 	int *index, i;
 
@@ -346,7 +346,7 @@ int *WeaponWeightIndex(weightconfig_t *wwc, weaponconfig_t *wc)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotFreeWeaponWeights(int weaponstate)
+static void BotFreeWeaponWeights(int weaponstate)
 {
 	bot_weaponstate_t *ws;
 

--- a/code/botlib/be_ai_weight.c
+++ b/code/botlib/be_ai_weight.c
@@ -48,7 +48,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define EVALUATERECURSIVELY
 
 #define MAX_WEIGHT_FILES			128
-weightconfig_t	*weightFileList[MAX_WEIGHT_FILES];
+static weightconfig_t	*weightFileList[MAX_WEIGHT_FILES];
 
 //===========================================================================
 //
@@ -56,7 +56,7 @@ weightconfig_t	*weightFileList[MAX_WEIGHT_FILES];
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int ReadValue(source_t *source, float *value)
+static int ReadValue(source_t *source, float *value)
 {
 	token_t token;
 
@@ -87,7 +87,7 @@ int ReadValue(source_t *source, float *value)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int ReadFuzzyWeight(source_t *source, fuzzyseperator_t *fs)
+static int ReadFuzzyWeight(source_t *source, fuzzyseperator_t *fs)
 {
 	if (PC_CheckTokenString(source, "balance"))
 	{
@@ -116,7 +116,7 @@ int ReadFuzzyWeight(source_t *source, fuzzyseperator_t *fs)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void FreeFuzzySeperators_r(fuzzyseperator_t *fs)
+static void FreeFuzzySeperators_r(fuzzyseperator_t *fs)
 {
 	if (!fs) return;
 	if (fs->child) FreeFuzzySeperators_r(fs->child);
@@ -129,7 +129,7 @@ void FreeFuzzySeperators_r(fuzzyseperator_t *fs)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void FreeWeightConfig2(weightconfig_t *config)
+static void FreeWeightConfig2(weightconfig_t *config)
 {
 	int i;
 
@@ -157,7 +157,7 @@ void FreeWeightConfig(weightconfig_t *config)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-fuzzyseperator_t *ReadFuzzySeperators_r(source_t *source)
+static fuzzyseperator_t *ReadFuzzySeperators_r(source_t *source)
 {
 	int newindent, index, def, founddefault;
 	token_t token;
@@ -448,7 +448,7 @@ weightconfig_t *ReadWeightConfig(char *filename)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-qboolean WriteFuzzyWeight(FILE *fp, fuzzyseperator_t *fs)
+static qboolean WriteFuzzyWeight(FILE *fp, fuzzyseperator_t *fs)
 {
 	if (fs->type == WT_BALANCE)
 	{
@@ -474,7 +474,7 @@ qboolean WriteFuzzyWeight(FILE *fp, fuzzyseperator_t *fs)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-qboolean WriteFuzzySeperators_r(FILE *fp, fuzzyseperator_t *fs, int indent)
+static qboolean WriteFuzzySeperators_r(FILE *fp, fuzzyseperator_t *fs, int indent)
 {
 	if (!WriteIndent(fp, indent)) return qfalse;
 	if (fprintf(fp, "switch(%d)\n", fs->index) < 0) return qfalse;
@@ -579,7 +579,7 @@ int FindFuzzyWeight(weightconfig_t *wc, char *name)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-float FuzzyWeight_r(int *inventory, fuzzyseperator_t *fs)
+static float FuzzyWeight_r(int *inventory, fuzzyseperator_t *fs)
 {
 	float scale, w1, w2;
 
@@ -616,7 +616,7 @@ float FuzzyWeight_r(int *inventory, fuzzyseperator_t *fs)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-float FuzzyWeightUndecided_r(int *inventory, fuzzyseperator_t *fs)
+static float FuzzyWeightUndecided_r(int *inventory, fuzzyseperator_t *fs)
 {
 	float scale, w1, w2;
 
@@ -715,7 +715,7 @@ float FuzzyWeightUndecided(int *inventory, weightconfig_t *wc, int weightnum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void EvolveFuzzySeperator_r(fuzzyseperator_t *fs)
+static void EvolveFuzzySeperator_r(fuzzyseperator_t *fs)
 {
 	if (fs->child)
 	{
@@ -753,7 +753,7 @@ void EvolveWeightConfig(weightconfig_t *config)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void ScaleFuzzySeperator_r(fuzzyseperator_t *fs, float scale)
+static void ScaleFuzzySeperator_r(fuzzyseperator_t *fs, float scale)
 {
 	if (fs->child)
 	{
@@ -796,7 +796,7 @@ void ScaleWeight(weightconfig_t *config, char *name, float scale)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void ScaleFuzzySeperatorBalanceRange_r(fuzzyseperator_t *fs, float scale)
+static void ScaleFuzzySeperatorBalanceRange_r(fuzzyseperator_t *fs, float scale)
 {
 	if (fs->child)
 	{
@@ -838,7 +838,7 @@ void ScaleFuzzyBalanceRange(weightconfig_t *config, float scale)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int InterbreedFuzzySeperator_r(fuzzyseperator_t *fs1, fuzzyseperator_t *fs2,
+static int InterbreedFuzzySeperator_r(fuzzyseperator_t *fs1, fuzzyseperator_t *fs2,
 								fuzzyseperator_t *fsout)
 {
 	if (fs1->child)

--- a/code/botlib/be_ea.c
+++ b/code/botlib/be_ea.c
@@ -41,7 +41,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define MAX_USERMOVE				400
 #define MAX_COMMANDARGUMENTS		10
 
-bot_input_t *botinputs;
+static bot_input_t *botinputs;
 
 //===========================================================================
 //

--- a/code/botlib/be_interface.c
+++ b/code/botlib/be_interface.c
@@ -116,7 +116,7 @@ static qboolean BotLibSetup(const char *str)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int Export_BotLibSetup( void )
+static int Export_BotLibSetup( void )
 {
 	int		errnum;
 	
@@ -160,7 +160,7 @@ int Export_BotLibSetup( void )
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int Export_BotLibShutdown(void)
+static int Export_BotLibShutdown(void)
 {
 	if ( !botlibglobals.botlibsetup )
 		return BLERR_LIBRARYNOTSETUP;
@@ -204,7 +204,7 @@ int Export_BotLibShutdown(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int Export_BotLibVarSet( const char *var_name, const char *value )
+static int Export_BotLibVarSet( const char *var_name, const char *value )
 {
 	LibVarSet( var_name, value );
 	return BLERR_NOERROR;
@@ -229,7 +229,7 @@ int Export_BotLibVarGet( const char *var_name, char *value, int size )
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int Export_BotLibStartFrame(float time)
+static int Export_BotLibStartFrame(float time)
 {
 	if (!BotLibSetup("BotStartFrame")) return BLERR_LIBRARYNOTSETUP;
 	return AAS_StartFrame(time);
@@ -240,7 +240,7 @@ int Export_BotLibStartFrame(float time)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int Export_BotLibLoadMap(const char *mapname)
+static int Export_BotLibLoadMap(const char *mapname)
 {
 #ifdef DEBUG
 	int starttime = Sys_MilliSeconds();

--- a/code/botlib/l_crc.c
+++ b/code/botlib/l_crc.c
@@ -48,7 +48,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define CRC_INIT_VALUE	0xffff
 #define CRC_XOR_VALUE	0x0000
 
-unsigned short crctable[257] =
+static unsigned short crctable[257] =
 {
 	0x0000,	0x1021,	0x2042,	0x3063,	0x4084,	0x50a5,	0x60c6,	0x70e7,
 	0x8108,	0x9129,	0xa14a,	0xb16b,	0xc18c,	0xd1ad,	0xe1ce,	0xf1ef,
@@ -90,7 +90,7 @@ unsigned short crctable[257] =
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void CRC_Init(unsigned short *crcvalue)
+static void CRC_Init(unsigned short *crcvalue)
 {
 	*crcvalue = CRC_INIT_VALUE;
 } //end of the function CRC_Init
@@ -110,7 +110,7 @@ void CRC_ProcessByte(unsigned short *crcvalue, byte data)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-unsigned short CRC_Value(unsigned short crcvalue)
+static unsigned short CRC_Value(unsigned short crcvalue)
 {
 	return crcvalue ^ CRC_XOR_VALUE;
 } //end of the function CRC_Value

--- a/code/botlib/l_crc.h
+++ b/code/botlib/l_crc.h
@@ -22,8 +22,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 typedef unsigned short crc_t;
 
-void CRC_Init(unsigned short *crcvalue);
 void CRC_ProcessByte(unsigned short *crcvalue, byte data);
-unsigned short CRC_Value(unsigned short crcvalue);
 unsigned short CRC_ProcessString(unsigned char *data, int length);
 void CRC_ContinueProcessString(unsigned short *crc, char *data, int length);

--- a/code/botlib/l_libvar.c
+++ b/code/botlib/l_libvar.c
@@ -42,7 +42,7 @@ libvar_t *libvarlist = NULL;
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-float LibVarStringValue( const char *string )
+static float LibVarStringValue( const char *string )
 {
 	int dotfound = 0;
 	float value = 0;

--- a/code/botlib/l_log.c
+++ b/code/botlib/l_log.c
@@ -93,7 +93,7 @@ void Log_Open( const char *filename )
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void Log_Close(void)
+static void Log_Close(void)
 {
 	if (!logfile.fp) return;
 	if (fclose(logfile.fp))

--- a/code/botlib/l_log.h
+++ b/code/botlib/l_log.h
@@ -31,8 +31,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 //open a log file
 void Log_Open( const char *filename );
-//close the current log file
-void Log_Close(void);
 //close log file if present
 void Log_Shutdown(void);
 //write to the current opened log file

--- a/code/botlib/l_memory.c
+++ b/code/botlib/l_memory.c
@@ -60,7 +60,7 @@ typedef struct memoryblock_s
 	struct memoryblock_s *prev, *next;
 } memoryblock_t;
 
-memoryblock_t *memory;
+static memoryblock_t *memory;
 
 //===========================================================================
 //
@@ -68,7 +68,7 @@ memoryblock_t *memory;
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void LinkMemoryBlock(memoryblock_t *block)
+static void LinkMemoryBlock(memoryblock_t *block)
 {
 	block->prev = NULL;
 	block->next = memory;
@@ -81,7 +81,7 @@ void LinkMemoryBlock(memoryblock_t *block)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void UnlinkMemoryBlock(memoryblock_t *block)
+static void UnlinkMemoryBlock(memoryblock_t *block)
 {
 	if (block->prev) block->prev->next = block->next;
 	else memory = block->next;
@@ -197,7 +197,7 @@ void *GetClearedHunkMemory(unsigned long size)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-memoryblock_t *BlockFromPointer(void *ptr, char *str)
+static memoryblock_t *BlockFromPointer(void *ptr, char *str)
 {
 	memoryblock_t *block;
 

--- a/code/botlib/l_precomp.c
+++ b/code/botlib/l_precomp.c
@@ -109,7 +109,7 @@ typedef struct directive_s
 
 #define TOKEN_HEAP_SIZE		4096
 
-int numtokens;
+static int numtokens;
 /*
 int tokenheapinitialized;				//true when the token heap is initialized
 token_t token_heap[TOKEN_HEAP_SIZE];	//heap with tokens
@@ -117,7 +117,7 @@ token_t *freetokens;					//free tokens from the heap
 */
 
 //list with global defines added to every source loaded
-define_t *globaldefines;
+static define_t *globaldefines;
 
 //============================================================================
 //
@@ -173,7 +173,7 @@ void QDECL SourceWarning(source_t *source, const char *fmt, ...)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_PushIndent(source_t *source, int type, int skip)
+static void PC_PushIndent(source_t *source, int type, int skip)
 {
 	indent_t *indent;
 
@@ -191,7 +191,7 @@ void PC_PushIndent(source_t *source, int type, int skip)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_PopIndent(source_t *source, int *type, int *skip)
+static void PC_PopIndent(source_t *source, int *type, int *skip)
 {
 	indent_t *indent;
 
@@ -216,7 +216,7 @@ void PC_PopIndent(source_t *source, int *type, int *skip)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_PushScript(source_t *source, script_t *script)
+static void PC_PushScript(source_t *source, script_t *script)
 {
 	script_t *s;
 
@@ -238,7 +238,7 @@ void PC_PushScript(source_t *source, script_t *script)
 // Returns:				-
 // Changes Globals:		-
 //============================================================================
-void PC_InitTokenHeap(void)
+static void PC_InitTokenHeap(void)
 {
 	/*
 	int i;
@@ -259,7 +259,7 @@ void PC_InitTokenHeap(void)
 // Returns:				-
 // Changes Globals:		-
 //============================================================================
-token_t *PC_CopyToken(token_t *token)
+static token_t *PC_CopyToken(token_t *token)
 {
 	token_t *t;
 
@@ -287,7 +287,7 @@ token_t *PC_CopyToken(token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_FreeToken(token_t *token)
+static void PC_FreeToken(token_t *token)
 {
 	//free(token);
 	FreeMemory(token);
@@ -301,7 +301,7 @@ void PC_FreeToken(token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_ReadSourceToken(source_t *source, token_t *token)
+static int PC_ReadSourceToken(source_t *source, token_t *token)
 {
 	token_t *t;
 	script_t *script;
@@ -344,7 +344,7 @@ int PC_ReadSourceToken(source_t *source, token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_UnreadSourceToken(source_t *source, token_t *token)
+static int PC_UnreadSourceToken(source_t *source, token_t *token)
 {
 	token_t *t;
 
@@ -359,7 +359,7 @@ int PC_UnreadSourceToken(source_t *source, token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_ReadDefineParms(source_t *source, define_t *define, token_t **parms, int maxparms)
+static int PC_ReadDefineParms(source_t *source, define_t *define, token_t **parms, int maxparms)
 {
 	token_t token, *t, *last;
 	int i, done, lastcomma, numparms, indent;
@@ -459,7 +459,7 @@ int PC_ReadDefineParms(source_t *source, define_t *define, token_t **parms, int 
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_StringizeTokens( const token_t *tokens, token_t *token )
+static int PC_StringizeTokens( const token_t *tokens, token_t *token )
 {
 	const token_t *t;
 	int len, total;
@@ -489,7 +489,7 @@ int PC_StringizeTokens( const token_t *tokens, token_t *token )
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_MergeTokens(token_t *t1, token_t *t2)
+static int PC_MergeTokens(token_t *t1, token_t *t2)
 {
 	//merging of a name with a name or number
 	if (t1->type == TT_NAME && (t2->type == TT_NAME || t2->type == TT_NUMBER))
@@ -564,7 +564,7 @@ void PC_PrintDefineHashTable(define_t **definehash)
 //============================================================================
 //char primes[16] = {1, 3, 5, 7, 11, 13, 17, 19, 23, 27, 29, 31, 37, 41, 43, 47};
 
-int PC_NameHash(char *name)
+static int PC_NameHash(char *name)
 {
 	int hash, i;
 
@@ -584,7 +584,7 @@ int PC_NameHash(char *name)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_AddDefineToHash(define_t *define, define_t **definehash)
+static void PC_AddDefineToHash(define_t *define, define_t **definehash)
 {
 	int hash;
 
@@ -598,7 +598,7 @@ void PC_AddDefineToHash(define_t *define, define_t **definehash)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-define_t *PC_FindHashedDefine(define_t **definehash, char *name)
+static define_t *PC_FindHashedDefine(define_t **definehash, char *name)
 {
 	define_t *d;
 	int hash;
@@ -617,7 +617,7 @@ define_t *PC_FindHashedDefine(define_t **definehash, char *name)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-define_t *PC_FindDefine(define_t *defines, char *name)
+static define_t *PC_FindDefine(define_t *defines, char *name)
 {
 	define_t *d;
 
@@ -634,7 +634,7 @@ define_t *PC_FindDefine(define_t *defines, char *name)
 //								if no parm found with the given name -1 is returned
 // Changes Globals:		-
 //============================================================================
-int PC_FindDefineParm(define_t *define, char *name)
+static int PC_FindDefineParm(define_t *define, char *name)
 {
 	token_t *p;
 	int i;
@@ -653,7 +653,7 @@ int PC_FindDefineParm(define_t *define, char *name)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_FreeDefine(define_t *define)
+static void PC_FreeDefine(define_t *define)
 {
 	token_t *t, *next;
 
@@ -719,7 +719,7 @@ void PC_AddBuiltinDefines(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_ExpandBuiltinDefine(source_t *source, token_t *deftoken, define_t *define,
+static int PC_ExpandBuiltinDefine(source_t *source, token_t *deftoken, define_t *define,
 										token_t **firsttoken, token_t **lasttoken)
 {
 	token_t *token;
@@ -795,7 +795,7 @@ int PC_ExpandBuiltinDefine(source_t *source, token_t *deftoken, define_t *define
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_ExpandDefine(source_t *source, token_t *deftoken, define_t *define,
+static int PC_ExpandDefine(source_t *source, token_t *deftoken, define_t *define,
 										token_t **firsttoken, token_t **lasttoken)
 {
 	token_t *parms[MAX_DEFINEPARMS] = { NULL }, *dt, *pt, *t;
@@ -933,7 +933,7 @@ int PC_ExpandDefine(source_t *source, token_t *deftoken, define_t *define,
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_ExpandDefineIntoSource(source_t *source, token_t *deftoken, define_t *define)
+static int PC_ExpandDefineIntoSource(source_t *source, token_t *deftoken, define_t *define)
 {
 	token_t *firsttoken, *lasttoken;
 
@@ -953,7 +953,7 @@ int PC_ExpandDefineIntoSource(source_t *source, token_t *deftoken, define_t *def
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_ConvertPath(char *path)
+static void PC_ConvertPath(char *path)
 {
 	char *ptr;
 
@@ -983,7 +983,7 @@ void PC_ConvertPath(char *path)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_include(source_t *source)
+static int PC_Directive_include(source_t *source)
 {
 	script_t *script;
 	token_t token;
@@ -1075,7 +1075,7 @@ int PC_Directive_include(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_ReadLine(source_t *source, token_t *token)
+static int PC_ReadLine(source_t *source, token_t *token)
 {
 	int crossline;
 
@@ -1099,7 +1099,7 @@ int PC_ReadLine(source_t *source, token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_WhiteSpaceBeforeToken(token_t *token)
+static int PC_WhiteSpaceBeforeToken(token_t *token)
 {
 	return token->endwhitespace_p - token->whitespace_p > 0;
 } //end of the function PC_WhiteSpaceBeforeToken
@@ -1109,7 +1109,7 @@ int PC_WhiteSpaceBeforeToken(token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_ClearTokenWhiteSpace(token_t *token)
+static void PC_ClearTokenWhiteSpace(token_t *token)
 {
 	token->whitespace_p = NULL;
 	token->endwhitespace_p = NULL;
@@ -1121,7 +1121,7 @@ void PC_ClearTokenWhiteSpace(token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_undef(source_t *source)
+static int PC_Directive_undef(source_t *source)
 {
 	token_t token;
 	define_t *define, *lastdefine;
@@ -1189,7 +1189,7 @@ int PC_Directive_undef(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_define(source_t *source)
+static int PC_Directive_define(source_t *source)
 {
 	token_t token, *t, *last;
 	define_t *define;
@@ -1326,7 +1326,7 @@ int PC_Directive_define(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-define_t *PC_DefineFromString(const char *string)
+static define_t *PC_DefineFromString(const char *string)
 {
 	script_t *script;
 	source_t src;
@@ -1457,7 +1457,7 @@ void PC_RemoveAllGlobalDefines(void)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-define_t *PC_CopyDefine(source_t *source, define_t *define)
+static define_t *PC_CopyDefine(source_t *source, define_t *define)
 {
 	define_t *newdefine;
 	token_t *token, *newtoken, *lasttoken;
@@ -1500,7 +1500,7 @@ define_t *PC_CopyDefine(source_t *source, define_t *define)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_AddGlobalDefinesToSource(source_t *source)
+static void PC_AddGlobalDefinesToSource(source_t *source)
 {
 	define_t *define, *newdefine;
 
@@ -1521,7 +1521,7 @@ void PC_AddGlobalDefinesToSource(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_if_def(source_t *source, int type)
+static int PC_Directive_if_def(source_t *source, int type)
 {
 	token_t token;
 	define_t *d;
@@ -1553,7 +1553,7 @@ int PC_Directive_if_def(source_t *source, int type)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_ifdef(source_t *source)
+static int PC_Directive_ifdef(source_t *source)
 {
 	return PC_Directive_if_def(source, INDENT_IFDEF);
 } //end of the function PC_Directive_ifdef
@@ -1563,7 +1563,7 @@ int PC_Directive_ifdef(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_ifndef(source_t *source)
+static int PC_Directive_ifndef(source_t *source)
 {
 	return PC_Directive_if_def(source, INDENT_IFNDEF);
 } //end of the function PC_Directive_ifndef
@@ -1573,7 +1573,7 @@ int PC_Directive_ifndef(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_else(source_t *source)
+static int PC_Directive_else(source_t *source)
 {
 	int type, skip;
 
@@ -1597,7 +1597,7 @@ int PC_Directive_else(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_endif(source_t *source)
+static int PC_Directive_endif(source_t *source)
 {
 	int type, skip;
 
@@ -1631,7 +1631,7 @@ typedef struct value_s
 	struct value_s *prev, *next;
 } value_t;
 
-int PC_OperatorPriority(int op)
+static int PC_OperatorPriority(int op)
 {
 	switch(op)
 	{
@@ -2350,7 +2350,7 @@ static int PC_DollarEvaluate(source_t *source, int *intvalue, float *floatvalue,
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_elif(source_t *source)
+static int PC_Directive_elif(source_t *source)
 {
 	int value;
 	int type, skip;
@@ -2372,7 +2372,7 @@ int PC_Directive_elif(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_if(source_t *source)
+static int PC_Directive_if(source_t *source)
 {
 	int value;
 	int skip;
@@ -2388,7 +2388,7 @@ int PC_Directive_if(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_line(source_t *source)
+static int PC_Directive_line(source_t *source)
 {
 	SourceError(source, "#line directive not supported");
 	return qfalse;
@@ -2399,7 +2399,7 @@ int PC_Directive_line(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_error(source_t *source)
+static int PC_Directive_error(source_t *source)
 {
 	token_t token;
 
@@ -2414,7 +2414,7 @@ int PC_Directive_error(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_pragma(source_t *source)
+static int PC_Directive_pragma(source_t *source)
 {
 	token_t token;
 
@@ -2428,7 +2428,7 @@ int PC_Directive_pragma(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void UnreadSignToken(source_t *source)
+static void UnreadSignToken(source_t *source)
 {
 	token_t token;
 
@@ -2447,7 +2447,7 @@ void UnreadSignToken(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_eval(source_t *source)
+static int PC_Directive_eval(source_t *source)
 {
 	int value;
 	token_t token;
@@ -2471,7 +2471,7 @@ int PC_Directive_eval(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_Directive_evalfloat(source_t *source)
+static int PC_Directive_evalfloat(source_t *source)
 {
 	float value;
 	token_t token;
@@ -2513,7 +2513,7 @@ directive_t directives[20] =
 	{NULL, NULL}
 };
 
-int PC_ReadDirective(source_t *source)
+static int PC_ReadDirective(source_t *source)
 {
 	token_t token;
 	int i;
@@ -2552,7 +2552,7 @@ int PC_ReadDirective(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_DollarDirective_evalint(source_t *source)
+static int PC_DollarDirective_evalint(source_t *source)
 {
 	int value;
 	token_t token;
@@ -2584,7 +2584,7 @@ int PC_DollarDirective_evalint(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_DollarDirective_evalfloat(source_t *source)
+static int PC_DollarDirective_evalfloat(source_t *source)
 {
 	float value;
 	token_t token;
@@ -2622,7 +2622,7 @@ directive_t dollardirectives[20] =
 	{NULL, NULL}
 };
 
-int PC_ReadDollarDirective(source_t *source)
+static int PC_ReadDollarDirective(source_t *source)
 {
 	token_t token;
 	int i;

--- a/code/botlib/l_precomp.h
+++ b/code/botlib/l_precomp.h
@@ -125,10 +125,6 @@ int PC_SkipUntilString(source_t *source, char *string);
 void PC_UnreadLastToken(source_t *source);
 //unread the given token
 void PC_UnreadToken(source_t *source, token_t *token);
-//read a token only if on the same line, lines are concatenated with a slash
-int PC_ReadLine(source_t *source, token_t *token);
-//returns true if there was a white space in front of the token
-int PC_WhiteSpaceBeforeToken(token_t *token);
 //add a define to the source
 int PC_AddDefine(source_t *source, char *string);
 //add a globals define that will be added to all opened sources

--- a/code/botlib/l_script.c
+++ b/code/botlib/l_script.c
@@ -83,7 +83,7 @@ typedef enum {qfalse, qtrue}	qboolean;
 #define PUNCTABLE
 
 //longer punctuations first
-punctuation_t default_punctuations[] =
+static punctuation_t default_punctuations[] =
 {
 	//binary operators
 	{">>=",P_RSHIFT_ASSIGN, NULL},
@@ -172,7 +172,7 @@ static char basefolder[MAX_QPATH];
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void PS_CreatePunctuationTable(script_t *script, punctuation_t *punctuations)
+static void PS_CreatePunctuationTable(script_t *script, punctuation_t *punctuations)
 {
 	int i;
 	punctuation_t *p, *lastp, *newp;
@@ -254,7 +254,7 @@ void QDECL ScriptError(script_t *script, const char *fmt, ...)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void QDECL ScriptWarning(script_t *script, const char *fmt, ...)
+static void QDECL ScriptWarning(script_t *script, const char *fmt, ...)
 {
 	char text[1024];
 	va_list ap;
@@ -280,7 +280,7 @@ void QDECL ScriptWarning(script_t *script, const char *fmt, ...)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void SetScriptPunctuations(script_t *script, punctuation_t *p)
+static void SetScriptPunctuations(script_t *script, punctuation_t *p)
 {
 #ifdef PUNCTABLE
 	if (p) PS_CreatePunctuationTable(script, p);
@@ -297,7 +297,7 @@ void SetScriptPunctuations(script_t *script, punctuation_t *p)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PS_ReadWhiteSpace(script_t *script)
+static int PS_ReadWhiteSpace(script_t *script)
 {
 	while(1)
 	{
@@ -356,7 +356,7 @@ int PS_ReadWhiteSpace(script_t *script)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PS_ReadEscapeCharacter(script_t *script, char *ch)
+static int PS_ReadEscapeCharacter(script_t *script, char *ch)
 {
 	int c, val, i;
 
@@ -434,7 +434,7 @@ int PS_ReadEscapeCharacter(script_t *script, char *ch)
 // Returns:					qtrue when a string was read successfully
 // Changes Globals:		-
 //============================================================================
-int PS_ReadString(script_t *script, token_t *token, int quote)
+static int PS_ReadString(script_t *script, token_t *token, int quote)
 {
 	int len, tmpline;
 	char *tmpscript_p;
@@ -523,7 +523,7 @@ int PS_ReadString(script_t *script, token_t *token, int quote)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PS_ReadName(script_t *script, token_t *token)
+static int PS_ReadName(script_t *script, token_t *token)
 {
 	int len = 0;
 	char c;
@@ -553,7 +553,7 @@ int PS_ReadName(script_t *script, token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void NumberValue(char *string, int subtype, unsigned long int *intvalue,
+static void NumberValue(char *string, int subtype, unsigned long int *intvalue,
 															float *floatvalue)
 {
 	unsigned long int dotfound = 0;
@@ -625,7 +625,7 @@ void NumberValue(char *string, int subtype, unsigned long int *intvalue,
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PS_ReadNumber(script_t *script, token_t *token)
+static int PS_ReadNumber(script_t *script, token_t *token)
 {
 	int len = 0, i;
 	int octal, dot;
@@ -780,7 +780,7 @@ int PS_ReadLiteral(script_t *script, token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PS_ReadPunctuation(script_t *script, token_t *token)
+static int PS_ReadPunctuation(script_t *script, token_t *token)
 {
 	int len;
 	char *p;
@@ -821,7 +821,7 @@ int PS_ReadPunctuation(script_t *script, token_t *token)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PS_ReadPrimitive(script_t *script, token_t *token)
+static int PS_ReadPrimitive(script_t *script, token_t *token)
 {
 	int len;
 
@@ -1304,7 +1304,7 @@ int ScriptSkipTo(script_t *script, char *value)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int FileLength(FILE *fp)
+static int FileLength(FILE *fp)
 {
 	int pos;
 	int end;

--- a/code/botlib/l_script.h
+++ b/code/botlib/l_script.h
@@ -219,8 +219,6 @@ void StripSingleQuotes(char *string);
 signed long int ReadSignedInt(script_t *script);
 //read a possible signed floating point number
 float ReadSignedFloat(script_t *script);
-//set an array with punctuations, NULL restores default C/C++ set
-void SetScriptPunctuations(script_t *script, punctuation_t *p);
 //set script flags
 void SetScriptFlags(script_t *script, int flags);
 //get script flags
@@ -241,7 +239,5 @@ void FreeScript(script_t *script);
 void PS_SetBaseFolder(const char *path);
 //print a script error with filename and line number
 void QDECL ScriptError(script_t *script, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-//print a script warning with filename and line number
-void QDECL ScriptWarning(script_t *script, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -1340,7 +1340,7 @@ CL_RequestMotd
 ===================
 */
 #if 0
-void CL_RequestMotd( void ) {
+static void CL_RequestMotd( void ) {
 	char		info[MAX_INFO_STRING];
 
 	if ( !cl_motd->integer ) {

--- a/code/client/cl_parse.c
+++ b/code/client/cl_parse.c
@@ -38,7 +38,7 @@ static const char *svc_strings[256] = {
 	"svc_voipOpus",  // ioq3 extension
 };
 
-void SHOWNET( msg_t *msg, const char *s ) {
+static void SHOWNET( msg_t *msg, const char *s ) {
 	if ( cl_shownet->integer >= 2) {
 		Com_Printf ("%3i:%s\n", msg->readcount-1, s);
 	}

--- a/code/client/cl_scrn.c
+++ b/code/client/cl_scrn.c
@@ -23,13 +23,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "client.h"
 
-qboolean	scr_initialized;		// ready to draw
+static qboolean	scr_initialized;		// ready to draw
 
 cvar_t		*cl_timegraph;
-cvar_t		*cl_debuggraph;
-cvar_t		*cl_graphheight;
-cvar_t		*cl_graphscale;
-cvar_t		*cl_graphshift;
+static cvar_t		*cl_debuggraph;
+static cvar_t		*cl_graphheight;
+static cvar_t		*cl_graphscale;
+static cvar_t		*cl_graphshift;
 
 /*
 ================

--- a/code/client/cl_ui.c
+++ b/code/client/cl_ui.c
@@ -584,7 +584,7 @@ static int LAN_ServerIsVisible(int source, int n ) {
 LAN_UpdateVisiblePings
 =======================
 */
-qboolean LAN_UpdateVisiblePings(int source ) {
+static qboolean LAN_UpdateVisiblePings(int source ) {
 	return CL_UpdateVisiblePings_f(source);
 }
 

--- a/code/qcommon/cm_load.c
+++ b/code/qcommon/cm_load.c
@@ -70,7 +70,7 @@ static cbrush_t *box_brush;
 
 
 
-void	CM_InitBoxHull (void);
+static void	CM_InitBoxHull (void);
 void	CM_FloodAreaConnections (void);
 
 
@@ -795,7 +795,7 @@ Set up the planes and nodes so that the six floats of a bounding box
 can just be stored out and get a proper clipping hull structure.
 ===================
 */
-void CM_InitBoxHull( void )
+static void CM_InitBoxHull( void )
 {
 	int			i;
 	int			side;

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -84,7 +84,7 @@ cvar_t	*com_version;
 static cvar_t *com_buildScript;	// for automated data building scripts
 
 #ifndef DEDICATED
-cvar_t	*com_introPlayed;
+static cvar_t	*com_introPlayed;
 cvar_t	*com_skipIdLogo;
 
 cvar_t	*cl_paused;

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -362,7 +362,7 @@ static char		*fs_serverReferencedPakNames[MAX_REF_PAKS];	// pk3 names
 int	fs_lastPakIndex;
 
 #ifdef FS_MISSING
-FILE*		missingFiles = NULL;
+static FILE*		missingFiles = NULL;
 #endif
 
 void Com_AppendCDKey( const char *filename );

--- a/code/qcommon/msg.c
+++ b/code/qcommon/msg.c
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "q_shared.h"
 #include "qcommon.h"
 
-int pcount[256];
+static int pcount[256];
 
 /*
 ==============================================================================

--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -936,7 +936,7 @@ __reswitch:
 COM_MatchToken
 ==================
 */
-void COM_MatchToken( const char **buf_p, const char *match ) {
+static void COM_MatchToken( const char **buf_p, const char *match ) {
 	const char *token;
 
 	token = COM_Parse( buf_p );

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -754,8 +754,6 @@ typedef struct pc_token_s
 
 // data is an in/out parm, returns a parsed out token
 
-void COM_MatchToken( const char**buf_p, const char *match );
-
 qboolean SkipBracedSection( const char **program, int depth );
 void SkipRestOfLine( const char **data );
 

--- a/code/qcommon/vm.c
+++ b/code/qcommon/vm.c
@@ -389,7 +389,7 @@ const char *VM_SymbolForCompiledPointer( vm_t *vm, void *code ) {
 ParseHex
 ===============
 */
-int	ParseHex( const char *text ) {
+static int	ParseHex( const char *text ) {
 	int		value;
 	int		c;
 
@@ -418,7 +418,7 @@ int	ParseHex( const char *text ) {
 VM_LoadSymbols
 ===============
 */
-void VM_LoadSymbols( vm_t *vm ) {
+static void VM_LoadSymbols( vm_t *vm ) {
 	union {
 		char	*c;
 		void	*v;

--- a/code/renderer/tr_local.h
+++ b/code/renderer/tr_local.h
@@ -1321,7 +1321,7 @@ void R_AddLitSurf( surfaceType_t *surface, shader_t *shader, int fogIndex );
 #define	CULL_IN		0		// completely unclipped
 #define	CULL_CLIP	1		// clipped by one or more planes
 #define	CULL_OUT	2		// completely outside the clipping planes
-void R_LocalNormalToWorld( const vec3_t local, vec3_t world );
+
 void R_LocalPointToWorld( const vec3_t local, vec3_t world );
 int R_CullLocalBox( const vec3_t bounds[2] );
 int R_CullPointAndRadius( const vec3_t origin, float radius );
@@ -1614,11 +1614,9 @@ SKIES
 ============================================================
 */
 
-void R_BuildCloudData( shaderCommands_t *shader );
 void R_InitSkyTexCoords( float cloudLayerHeight );
 void R_DrawSkyBox( shaderCommands_t *shader );
 void RB_DrawSun( float scale, shader_t *shader );
-void RB_ClipSkyPolygons( shaderCommands_t *shader );
 
 /*
 ============================================================

--- a/code/renderer/tr_main.c
+++ b/code/renderer/tr_main.c
@@ -206,7 +206,7 @@ int R_CullDlight( const dlight_t* dl )
 R_LocalNormalToWorld
 =================
 */
-void R_LocalNormalToWorld( const vec3_t local, vec3_t world ) {
+static void R_LocalNormalToWorld( const vec3_t local, vec3_t world ) {
 	world[0] = local[0] * tr.or.axis[0][0] + local[1] * tr.or.axis[1][0] + local[2] * tr.or.axis[2][0];
 	world[1] = local[0] * tr.or.axis[0][1] + local[1] * tr.or.axis[1][1] + local[2] * tr.or.axis[2][1];
 	world[2] = local[0] * tr.or.axis[0][2] + local[1] * tr.or.axis[1][2] + local[2] * tr.or.axis[2][2];
@@ -306,7 +306,7 @@ void R_TransformClipToWindow( const vec4_t clip, const viewParms_t *view, vec4_t
 myGlMultMatrix
 ==========================
 */
-void myGlMultMatrix( const float *a, const float *b, float *out ) {
+static void myGlMultMatrix( const float *a, const float *b, float *out ) {
 	int		i, j;
 
 	for ( i = 0 ; i < 4 ; i++ ) {
@@ -1541,7 +1541,7 @@ static void R_SortDrawSurfs( drawSurf_t *drawSurfs, int numDrawSurfs ) {
 R_AddEntitySurfaces
 =============
 */
-void R_AddEntitySurfaces( void ) {
+static void R_AddEntitySurfaces( void ) {
 	trRefEntity_t	*ent;
 	shader_t		*shader;
 
@@ -1633,7 +1633,7 @@ void R_AddEntitySurfaces( void ) {
 R_GenerateDrawSurfs
 ====================
 */
-void R_GenerateDrawSurfs( void ) {
+static void R_GenerateDrawSurfs( void ) {
 	R_AddWorldSurfaces ();
 
 	R_AddPolygonSurfaces();

--- a/code/renderer/tr_marks.c
+++ b/code/renderer/tr_marks.c
@@ -133,7 +133,7 @@ R_BoxSurfaces_r
 
 =================
 */
-void R_BoxSurfaces_r(mnode_t *node, vec3_t mins, vec3_t maxs, surfaceType_t **list, int listsize, int *listlength, vec3_t dir) {
+static void R_BoxSurfaces_r(mnode_t *node, vec3_t mins, vec3_t maxs, surfaceType_t **list, int listsize, int *listlength, vec3_t dir) {
 
 	int			s, c;
 	msurface_t	*surf, **mark;
@@ -195,7 +195,7 @@ R_AddMarkFragments
 
 =================
 */
-void R_AddMarkFragments(int numClipPoints, vec3_t clipPoints[2][MAX_VERTS_ON_POLY],
+static void R_AddMarkFragments(int numClipPoints, vec3_t clipPoints[2][MAX_VERTS_ON_POLY],
 				   int numPlanes, vec3_t *normals, float *dists,
 				   int maxPoints, vec3_t pointBuffer,
 				   int maxFragments, markFragment_t *fragmentBuffer,

--- a/code/renderer/tr_mesh.c
+++ b/code/renderer/tr_mesh.c
@@ -242,7 +242,7 @@ int R_ComputeLOD( trRefEntity_t *ent ) {
 R_ComputeFogNum
 =================
 */
-int R_ComputeFogNum( md3Header_t *header, trRefEntity_t *ent ) {
+static int R_ComputeFogNum( md3Header_t *header, trRefEntity_t *ent ) {
 	int				i, j;
 	fog_t			*fog;
 	md3Frame_t		*md3Frame;

--- a/code/renderer/tr_model.c
+++ b/code/renderer/tr_model.c
@@ -33,7 +33,7 @@ static qboolean R_LoadMDR(model_t *mod, void *buffer, int filesize, const char *
 R_RegisterMD3
 ====================
 */
-qhandle_t R_RegisterMD3(const char *name, model_t *mod)
+static qhandle_t R_RegisterMD3(const char *name, model_t *mod)
 {
 	union {
 		uint32_t *u;
@@ -119,7 +119,7 @@ qhandle_t R_RegisterMD3(const char *name, model_t *mod)
 R_RegisterMDR
 ====================
 */
-qhandle_t R_RegisterMDR(const char *name, model_t *mod)
+static qhandle_t R_RegisterMDR(const char *name, model_t *mod)
 {
 	union {
 		uint32_t *u;
@@ -163,7 +163,7 @@ qhandle_t R_RegisterMDR(const char *name, model_t *mod)
 R_RegisterIQM
 ====================
 */
-qhandle_t R_RegisterIQM(const char *name, model_t *mod)
+static qhandle_t R_RegisterIQM(const char *name, model_t *mod)
 {
 	union {
 		unsigned *u;
@@ -1039,7 +1039,7 @@ static md3Tag_t *R_GetTag( md3Header_t *mod, int frame, const char *tagName ) {
 	return NULL;
 }
 
-md3Tag_t *R_GetAnimTag( mdrHeader_t *mod, int framenum, const char *tagName, md3Tag_t * dest) 
+static md3Tag_t *R_GetAnimTag( mdrHeader_t *mod, int framenum, const char *tagName, md3Tag_t * dest) 
 {
 	int				i, j, k;
 	int				frameSize;

--- a/code/renderer/tr_scene.c
+++ b/code/renderer/tr_scene.c
@@ -243,7 +243,7 @@ void RE_AddRefEntityToScene( const refEntity_t *ent, qboolean intShaderTime ) {
 RE_AddDynamicLightToScene
 =====================
 */
-void RE_AddDynamicLightToScene( const vec3_t org, float intensity, float r, float g, float b, int additive ) {
+static void RE_AddDynamicLightToScene( const vec3_t org, float intensity, float r, float g, float b, int additive ) {
 	dlight_t	*dl;
 
 	if ( !tr.registered ) {

--- a/code/renderer/tr_shade_calc.c
+++ b/code/renderer/tr_shade_calc.c
@@ -117,7 +117,7 @@ DEFORMATIONS
 RB_CalcDeformVertexes
 ========================
 */
-void RB_CalcDeformVertexes( deformStage_t *ds )
+static void RB_CalcDeformVertexes( deformStage_t *ds )
 {
 	int i;
 	vec3_t	offset;
@@ -169,7 +169,7 @@ RB_CalcDeformNormals
 Wiggle the normals for wavy environment mapping
 =========================
 */
-void RB_CalcDeformNormals( deformStage_t *ds ) {
+static void RB_CalcDeformNormals( deformStage_t *ds ) {
 	int i;
 	float	scale;
 	float	*xyz = ( float * ) tess.xyz;
@@ -201,7 +201,7 @@ void RB_CalcDeformNormals( deformStage_t *ds ) {
 RB_CalcBulgeVertexes
 ========================
 */
-void RB_CalcBulgeVertexes( deformStage_t *ds ) {
+static void RB_CalcBulgeVertexes( deformStage_t *ds ) {
 	int i;
 	const float *st = ( const float * ) tess.texCoords[0][0];
 	float		*xyz = ( float * ) tess.xyz;
@@ -232,7 +232,7 @@ RB_CalcMoveVertexes
 A deformation that can move an entire surface along a wave path
 ======================
 */
-void RB_CalcMoveVertexes( deformStage_t *ds ) {
+static void RB_CalcMoveVertexes( deformStage_t *ds ) {
 	int			i;
 	float		*xyz;
 	float		*table;
@@ -262,7 +262,7 @@ DeformText
 Change a polygon into a bunch of text polygons
 =============
 */
-void DeformText( const char *text ) {
+static void DeformText( const char *text ) {
 	int		i;
 	vec3_t	origin, width, height;
 	int		len;

--- a/code/renderer/tr_shader.c
+++ b/code/renderer/tr_shader.c
@@ -1361,7 +1361,7 @@ static void ParseSkyParms( const char **text ) {
 ParseSort
 =================
 */
-void ParseSort( const char **text ) {
+static void ParseSort( const char **text ) {
 	char	*token;
 
 	token = COM_ParseExt( text, qfalse );

--- a/code/renderer/tr_sky.c
+++ b/code/renderer/tr_sky.c
@@ -257,7 +257,7 @@ static void ClearSkyBox (void) {
 RB_ClipSkyPolygons
 ================
 */
-void RB_ClipSkyPolygons( shaderCommands_t *input )
+static void RB_ClipSkyPolygons( shaderCommands_t *input )
 {
 	vec3_t		p[5];	// need one extra point for clipping
 	int			i, j;
@@ -625,7 +625,7 @@ static void FillCloudBox( void )
 /*
 ** R_BuildCloudData
 */
-void R_BuildCloudData( shaderCommands_t *input )
+static void R_BuildCloudData( shaderCommands_t *input )
 {
 	const shader_t *shader;
 

--- a/code/renderer2/tr_backend.c
+++ b/code/renderer2/tr_backend.c
@@ -322,7 +322,7 @@ Any mirrored or portaled views have already been drawn, so prepare
 to actually render the visible surfaces for this view
 =================
 */
-void RB_BeginDrawingView (void) {
+static void RB_BeginDrawingView (void) {
 	int clearBits = 0;
 
 	// sync with gl if needed
@@ -422,7 +422,7 @@ void RB_BeginDrawingView (void) {
 RB_RenderDrawSurfList
 ==================
 */
-void RB_RenderDrawSurfList( drawSurf_t *drawSurfs, int numDrawSurfs ) {
+static void RB_RenderDrawSurfList( drawSurf_t *drawSurfs, int numDrawSurfs ) {
 	shader_t		*shader, *oldShader;
 	int				fogNum, oldFogNum;
 	int				entityNum, oldEntityNum;
@@ -620,7 +620,7 @@ RB_SetGL2D
 
 ================
 */
-void	RB_SetGL2D (void) {
+static void	RB_SetGL2D (void) {
 	mat4_t matrix;
 	int width, height;
 
@@ -773,7 +773,7 @@ RB_SetColor
 
 =============
 */
-const void	*RB_SetColor( const void *data ) {
+static const void	*RB_SetColor( const void *data ) {
 	const setColorCommand_t	*cmd;
 
 	cmd = (const setColorCommand_t *)data;
@@ -791,7 +791,7 @@ const void	*RB_SetColor( const void *data ) {
 RB_StretchPic
 =============
 */
-const void *RB_StretchPic ( const void *data ) {
+static const void *RB_StretchPic ( const void *data ) {
 	const stretchPicCommand_t	*cmd;
 	shader_t *shader;
 	int		numVerts, numIndexes;
@@ -876,7 +876,7 @@ RB_DrawSurfs
 
 =============
 */
-const void	*RB_DrawSurfs( const void *data ) {
+static const void	*RB_DrawSurfs( const void *data ) {
 	const drawSurfsCommand_t	*cmd;
 	qboolean isShadowView;
 
@@ -1186,7 +1186,7 @@ RB_DrawBuffer
 
 =============
 */
-const void	*RB_DrawBuffer( const void *data ) {
+static const void	*RB_DrawBuffer( const void *data ) {
 	const drawBufferCommand_t	*cmd;
 
 	cmd = (const drawBufferCommand_t *)data;
@@ -1274,7 +1274,7 @@ RB_ColorMask
 
 =============
 */
-const void *RB_ColorMask(const void *data)
+static const void *RB_ColorMask(const void *data)
 {
 	const colorMaskCommand_t *cmd = data;
 
@@ -1302,7 +1302,7 @@ RB_ClearDepth
 
 =============
 */
-const void *RB_ClearDepth(const void *data)
+static const void *RB_ClearDepth(const void *data)
 {
 	const clearDepthCommand_t *cmd = data;
 	
@@ -1346,7 +1346,7 @@ RB_SwapBuffers
 
 =============
 */
-const void	*RB_SwapBuffers( const void *data ) {
+static const void	*RB_SwapBuffers( const void *data ) {
 	const swapBuffersCommand_t	*cmd;
 
 	// finish any 2D drawing if needed
@@ -1416,7 +1416,7 @@ RB_CapShadowMap
 
 =============
 */
-const void *RB_CapShadowMap(const void *data)
+static const void *RB_CapShadowMap(const void *data)
 {
 	const capShadowmapCommand_t *cmd = data;
 
@@ -1452,7 +1452,7 @@ RB_PostProcess
 
 =============
 */
-const void *RB_PostProcess(const void *data)
+static const void *RB_PostProcess(const void *data)
 {
 	const postProcessCommand_t *cmd = data;
 	FBO_t *srcFbo;
@@ -1672,7 +1672,7 @@ RB_ExportCubemaps
 
 =============
 */
-const void *RB_ExportCubemaps(const void *data)
+static const void *RB_ExportCubemaps(const void *data)
 {
 	const exportCubemapsCommand_t *cmd = data;
 

--- a/code/renderer2/tr_cmds.c
+++ b/code/renderer2/tr_cmds.c
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 R_PerformanceCounters
 =====================
 */
-void R_PerformanceCounters( void ) {
+static void R_PerformanceCounters( void ) {
 	if ( !r_speeds->integer ) {
 		// clear the counters even if we aren't printing
 		Com_Memset( &tr.pc, 0, sizeof( tr.pc ) );
@@ -82,7 +82,7 @@ void R_PerformanceCounters( void ) {
 R_IssueRenderCommands
 ====================
 */
-void R_IssueRenderCommands( qboolean runPerformanceCounters ) {
+static void R_IssueRenderCommands( qboolean runPerformanceCounters ) {
 	renderCommandList_t	*cmdList;
 
 	cmdList = &backEndData->commands;
@@ -126,7 +126,7 @@ R_GetCommandBufferReserved
 make sure there is enough command space
 ============
 */
-void *R_GetCommandBufferReserved( int bytes, int reservedBytes ) {
+static void *R_GetCommandBufferReserved( int bytes, int reservedBytes ) {
 	renderCommandList_t	*cmdList;
 
 	cmdList = &backEndData->commands;
@@ -285,7 +285,7 @@ void RE_StretchPic ( float x, float y, float w, float h,
 #define MODE_GREEN_MAGENTA 4
 #define MODE_MAX	MODE_GREEN_MAGENTA
 
-void R_SetColorMode(GLboolean *rgba, stereoFrame_t stereoFrame, int colormode)
+static void R_SetColorMode(GLboolean *rgba, stereoFrame_t stereoFrame, int colormode)
 {
 	rgba[0] = rgba[1] = rgba[2] = rgba[3] = GL_TRUE;
 	

--- a/code/renderer2/tr_fbo.c
+++ b/code/renderer2/tr_fbo.c
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 R_CheckFBO
 =============
 */
-qboolean R_CheckFBO(const FBO_t * fbo)
+static qboolean R_CheckFBO(const FBO_t * fbo)
 {
 	GLenum code = qglCheckNamedFramebufferStatusEXT(fbo->frameBuffer, GL_FRAMEBUFFER);
 
@@ -77,7 +77,7 @@ qboolean R_CheckFBO(const FBO_t * fbo)
 FBO_Create
 ============
 */
-FBO_t          *FBO_Create(const char *name, int width, int height)
+static FBO_t          *FBO_Create(const char *name, int width, int height)
 {
 	FBO_t          *fbo;
 
@@ -117,7 +117,7 @@ FBO_t          *FBO_Create(const char *name, int width, int height)
 FBO_CreateBuffer
 =================
 */
-void FBO_CreateBuffer(FBO_t *fbo, int format, int index, int multisample)
+static void FBO_CreateBuffer(FBO_t *fbo, int format, int index, int multisample)
 {
 	uint32_t *pRenderBuffer;
 	GLenum attachment;

--- a/code/renderer2/tr_image.c
+++ b/code/renderer2/tr_image.c
@@ -49,7 +49,7 @@ typedef struct {
 	int	minimize, maximize;
 } textureMode_t;
 
-textureMode_t modes[] = {
+static textureMode_t modes[] = {
 	{"GL_NEAREST", GL_NEAREST, GL_NEAREST},
 	{"GL_LINEAR", GL_LINEAR, GL_LINEAR},
 	{"GL_NEAREST_MIPMAP_NEAREST", GL_NEAREST_MIPMAP_NEAREST, GL_NEAREST},
@@ -1252,7 +1252,7 @@ Scale up the pixel values in a texture to increase the
 lighting range
 ================
 */
-void R_LightScaleTexture (byte *in, int inwidth, int inheight, qboolean only_gamma )
+static void R_LightScaleTexture (byte *in, int inwidth, int inheight, qboolean only_gamma )
 {
 	if ( only_gamma )
 	{
@@ -1436,7 +1436,7 @@ static void R_BlendOverTexture( byte *data, int pixelCount, byte blend[4] ) {
 	}
 }
 
-byte	mipBlendColors[16][4] = {
+static byte	mipBlendColors[16][4] = {
 	{0,0,0,0},
 	{255,0,0,128},
 	{0,255,0,128},
@@ -2094,7 +2094,7 @@ R_CreateImage2
 This is the only way any image_t are created
 ================
 */
-image_t *R_CreateImage2( const char *name, byte *pic, int width, int height, GLenum picFormat, int numMips, imgType_t type, imgFlags_t flags, int internalFormat ) {
+static image_t *R_CreateImage2( const char *name, byte *pic, int width, int height, GLenum picFormat, int numMips, imgType_t type, imgFlags_t flags, int internalFormat ) {
 	byte       *resampledBuffer = NULL;
 	image_t    *image;
 	qboolean    isLightmap = qfalse, scaled = qfalse;
@@ -2287,7 +2287,7 @@ Loads any of the supported image types into a canonical
 32 bit format.
 =================
 */
-void R_LoadImage( const char *name, byte **pic, int *width, int *height, GLenum *picFormat, int *numMips )
+static void R_LoadImage( const char *name, byte **pic, int *width, int *height, GLenum *picFormat, int *numMips )
 {
 	qboolean orgNameFailed = qfalse;
 	int orgLoader = -1;

--- a/code/renderer2/tr_init.c
+++ b/code/renderer2/tr_init.c
@@ -388,7 +388,7 @@ Return value must be freed with ri.Hunk_FreeTempMemory()
 ================== 
 */  
 
-byte *RB_ReadPixels(int x, int y, int width, int height, size_t *offset, int *padlen)
+static byte *RB_ReadPixels(int x, int y, int width, int height, size_t *offset, int *padlen)
 {
 	byte *buffer, *bufstart;
 	int padwidth, linelen;
@@ -417,7 +417,7 @@ byte *RB_ReadPixels(int x, int y, int width, int height, size_t *offset, int *pa
 RB_TakeScreenshot
 ================== 
 */  
-void RB_TakeScreenshot(int x, int y, int width, int height, char *fileName)
+static void RB_TakeScreenshot(int x, int y, int width, int height, char *fileName)
 {
 	byte *allbuf, *buffer;
 	byte *srcptr, *destptr;
@@ -479,7 +479,7 @@ RB_TakeScreenshotJPEG
 ================== 
 */
 
-void RB_TakeScreenshotJPEG(int x, int y, int width, int height, char *fileName)
+static void RB_TakeScreenshotJPEG(int x, int y, int width, int height, char *fileName)
 {
 	byte *buffer;
 	size_t offset = 0, memcount;
@@ -523,7 +523,7 @@ const void *RB_TakeScreenshotCmd( const void *data ) {
 R_TakeScreenshot
 ==================
 */
-void R_TakeScreenshot( int x, int y, int width, int height, char *name, qboolean jpeg ) {
+static void R_TakeScreenshot( int x, int y, int width, int height, char *name, qboolean jpeg ) {
 	static char	fileName[MAX_OSPATH]; // bad things if two screenshots per frame?
 	screenshotCommand_t	*cmd;
 
@@ -547,7 +547,7 @@ void R_TakeScreenshot( int x, int y, int width, int height, char *name, qboolean
 R_ScreenshotFilename
 ================== 
 */  
-void R_ScreenshotFilename( int lastNumber, char *fileName ) {
+static void R_ScreenshotFilename( int lastNumber, char *fileName ) {
 	int		a,b,c,d;
 
 	if ( lastNumber < 0 || lastNumber > 9999 ) {
@@ -572,7 +572,7 @@ void R_ScreenshotFilename( int lastNumber, char *fileName ) {
 R_ScreenshotFilename
 ================== 
 */  
-void R_ScreenshotFilenameJPEG( int lastNumber, char *fileName ) {
+static void R_ScreenshotFilenameJPEG( int lastNumber, char *fileName ) {
 	int		a,b,c,d;
 
 	if ( lastNumber < 0 || lastNumber > 9999 ) {
@@ -600,7 +600,7 @@ levelshots are specialized 128*128 thumbnails for
 the menu system, sampled down from full screen distorted images
 ====================
 */
-void R_LevelShot( void ) {
+static void R_LevelShot( void ) {
 	char		checkname[MAX_OSPATH];
 	byte		*buffer;
 	byte		*source, *allsource;
@@ -671,7 +671,7 @@ screenshot [filename]
 Doesn't print the pacifier message if there is a second arg
 ================== 
 */  
-void R_ScreenShot_f (void) {
+static void R_ScreenShot_f (void) {
 	char	checkname[MAX_OSPATH];
 	static	int	lastNumber = -1;
 	qboolean	silent;
@@ -724,7 +724,7 @@ void R_ScreenShot_f (void) {
 	}
 } 
 
-void R_ScreenShotJPEG_f (void) {
+static void R_ScreenShotJPEG_f (void) {
 	char		checkname[MAX_OSPATH];
 	static	int	lastNumber = -1;
 	qboolean	silent;
@@ -784,7 +784,7 @@ void R_ScreenShotJPEG_f (void) {
 R_ExportCubemaps
 ==================
 */
-void R_ExportCubemaps(void)
+static void R_ExportCubemaps(void)
 {
 	exportCubemapsCommand_t	*cmd;
 
@@ -801,7 +801,7 @@ void R_ExportCubemaps(void)
 R_ExportCubemaps_f
 ==================
 */
-void R_ExportCubemaps_f(void)
+static void R_ExportCubemaps_f(void)
 {
 	R_ExportCubemaps();
 }
@@ -951,7 +951,7 @@ R_PrintLongString
 Workaround for ri.Printf's 1024 characters buffer limit.
 ================
 */
-void R_PrintLongString(const char *string) {
+static void R_PrintLongString(const char *string) {
 	char buffer[1024];
 	const char *p;
 	int size = strlen(string);
@@ -971,7 +971,7 @@ void R_PrintLongString(const char *string) {
 GfxInfo_f
 ================
 */
-void GfxInfo_f( void ) 
+static void GfxInfo_f( void ) 
 {
 	const char *enablestrings[] =
 	{
@@ -1042,7 +1042,7 @@ void GfxInfo_f( void )
 GfxMemInfo_f
 ================
 */
-void GfxMemInfo_f( void ) 
+static void GfxMemInfo_f( void ) 
 {
 	switch (glRefConfig.memInfo)
 	{
@@ -1095,7 +1095,7 @@ void GfxMemInfo_f( void )
 R_Register
 ===============
 */
-void R_Register( void ) 
+static void R_Register( void ) 
 {
 	//
 	// latched and archived variables
@@ -1299,7 +1299,7 @@ void R_Register( void )
 	ri.Cmd_AddCommand( "exportCubemaps", R_ExportCubemaps_f );
 }
 
-void R_InitQueries(void)
+static void R_InitQueries(void)
 {
 	if (!glRefConfig.occlusionQuery)
 		return;
@@ -1308,7 +1308,7 @@ void R_InitQueries(void)
 		qglGenQueries(ARRAY_LEN(tr.sunFlareQuery), tr.sunFlareQuery);
 }
 
-void R_ShutDownQueries(void)
+static void R_ShutDownQueries(void)
 {
 	if (!glRefConfig.occlusionQuery)
 		return;
@@ -1488,7 +1488,7 @@ RE_EndRegistration
 Touch all images to make sure they are resident
 =============
 */
-void RE_EndRegistration( void ) {
+static void RE_EndRegistration( void ) {
 	R_IssuePendingRenderCommands();
 	if ( !ri.Sys_LowPhysicalMemory() ) {
 		RB_ShowImages();

--- a/code/renderer2/tr_local.h
+++ b/code/renderer2/tr_local.h
@@ -1879,7 +1879,7 @@ qboolean R_CalcTangentVectors(srfVert_t * dv[3]);
 #define	CULL_IN		0		// completely unclipped
 #define	CULL_CLIP	1		// clipped by one or more planes
 #define	CULL_OUT	2		// completely outside the clipping planes
-void R_LocalNormalToWorld (const vec3_t local, vec3_t world);
+
 void R_LocalPointToWorld (const vec3_t local, vec3_t world);
 int R_CullBox (vec3_t bounds[2]);
 int R_CullLocalBox( const vec3_t bounds[2] );
@@ -2137,11 +2137,9 @@ SKIES
 ============================================================
 */
 
-void R_BuildCloudData( shaderCommands_t *shader );
 void R_InitSkyTexCoords( float cloudLayerHeight );
 void R_DrawSkyBox( shaderCommands_t *shader );
 void RB_DrawSun( float scale, shader_t *shader );
-void RB_ClipSkyPolygons( shaderCommands_t *shader );
 
 /*
 ============================================================

--- a/code/renderer2/tr_main.c
+++ b/code/renderer2/tr_main.c
@@ -41,7 +41,7 @@ refimport_t	ri;
 
 // entities that will have procedurally generated surfaces will just
 // point at this for their sorting surface
-surfaceType_t	entitySurface = SF_ENTITY;
+static surfaceType_t	entitySurface = SF_ENTITY;
 
 /*
 ================
@@ -389,7 +389,7 @@ R_LocalNormalToWorld
 
 =================
 */
-void R_LocalNormalToWorld (const vec3_t local, vec3_t world) {
+static void R_LocalNormalToWorld (const vec3_t local, vec3_t world) {
 	world[0] = local[0] * tr.or.axis[0][0] + local[1] * tr.or.axis[1][0] + local[2] * tr.or.axis[2][0];
 	world[1] = local[0] * tr.or.axis[0][1] + local[1] * tr.or.axis[1][1] + local[2] * tr.or.axis[2][1];
 	world[2] = local[0] * tr.or.axis[0][2] + local[1] * tr.or.axis[1][2] + local[2] * tr.or.axis[2][2];
@@ -472,7 +472,7 @@ myGlMultMatrix
 
 ==========================
 */
-void myGlMultMatrix( const float *a, const float *b, float *out ) {
+static void myGlMultMatrix( const float *a, const float *b, float *out ) {
 	int		i, j;
 
 	for ( i = 0 ; i < 4 ; i++ ) {
@@ -563,7 +563,7 @@ R_RotateForViewer
 Sets up the modelview matrix for a given viewParm
 =================
 */
-void R_RotateForViewer (void) 
+static void R_RotateForViewer (void) 
 {
 	float	viewerMatrix[16];
 	vec3_t	origin;
@@ -677,7 +677,7 @@ Set up the culling frustum planes for the current view using the results we got 
 the projection matrix.
 =================
 */
-void R_SetupFrustum (viewParms_t *dest, float xmin, float xmax, float ymax, float zProj, float zFar, float stereoSep)
+static void R_SetupFrustum (viewParms_t *dest, float xmin, float xmax, float ymax, float zProj, float zFar, float stereoSep)
 {
 	vec3_t ofsorigin;
 	float oppleg, adjleg, length;
@@ -806,7 +806,7 @@ R_SetupProjectionZ
 Sets the z-component transformation part in the projection matrix
 ===============
 */
-void R_SetupProjectionZ(viewParms_t *dest)
+static void R_SetupProjectionZ(viewParms_t *dest)
 {
 	float zNear, zFar, depth;
 	
@@ -860,7 +860,7 @@ void R_SetupProjectionZ(viewParms_t *dest)
 R_SetupProjectionOrtho
 ===============
 */
-void R_SetupProjectionOrtho(viewParms_t *dest, vec3_t viewBounds[2])
+static void R_SetupProjectionOrtho(viewParms_t *dest, vec3_t viewBounds[2])
 {
 	float xmin, xmax, ymin, ymax, znear, zfar;
 	//viewParms_t *dest = &tr.viewParms;
@@ -935,7 +935,7 @@ void R_SetupProjectionOrtho(viewParms_t *dest, vec3_t viewBounds[2])
 R_MirrorPoint
 =================
 */
-void R_MirrorPoint (vec3_t in, orientation_t *surface, orientation_t *camera, vec3_t out) {
+static void R_MirrorPoint (vec3_t in, orientation_t *surface, orientation_t *camera, vec3_t out) {
 	int		i;
 	vec3_t	local;
 	vec3_t	transformed;
@@ -952,7 +952,7 @@ void R_MirrorPoint (vec3_t in, orientation_t *surface, orientation_t *camera, ve
 	VectorAdd( transformed, camera->origin, out );
 }
 
-void R_MirrorVector (vec3_t in, orientation_t *surface, orientation_t *camera, vec3_t out) {
+static void R_MirrorVector (vec3_t in, orientation_t *surface, orientation_t *camera, vec3_t out) {
 	int		i;
 	float	d;
 
@@ -969,7 +969,7 @@ void R_MirrorVector (vec3_t in, orientation_t *surface, orientation_t *camera, v
 R_PlaneForSurface
 =============
 */
-void R_PlaneForSurface (surfaceType_t *surfType, cplane_t *plane) {
+static void R_PlaneForSurface (surfaceType_t *surfType, cplane_t *plane) {
 	srfBspSurface_t	*tri;
 	srfPoly_t		*poly;
 	srfVert_t		*v1, *v2, *v3;
@@ -1016,7 +1016,7 @@ be moving and rotating.
 Returns qtrue if it should be mirrored
 =================
 */
-qboolean R_GetPortalOrientations( drawSurf_t *drawSurf, int entityNum, 
+static qboolean R_GetPortalOrientations( drawSurf_t *drawSurf, int entityNum, 
 							 orientation_t *surface, orientation_t *camera,
 							 vec3_t pvsOrigin, qboolean *mirror ) {
 	int			i;
@@ -1300,7 +1300,7 @@ R_MirrorViewBySurface
 Returns qtrue if another view has been rendered
 ========================
 */
-qboolean R_MirrorViewBySurface (drawSurf_t *drawSurf, int entityNum) {
+static qboolean R_MirrorViewBySurface (drawSurf_t *drawSurf, int entityNum) {
 	vec4_t			clipDest[128];
 	viewParms_t		newParms;
 	viewParms_t		oldParms;
@@ -1362,7 +1362,7 @@ R_SpriteFogNum
 See if a sprite is inside a fog volume
 =================
 */
-int R_SpriteFogNum( trRefEntity_t *ent ) {
+static int R_SpriteFogNum( trRefEntity_t *ent ) {
 	int				i, j;
 	fog_t			*fog;
 
@@ -1494,7 +1494,7 @@ void R_DecomposeSort( unsigned sort, int *entityNum, shader_t **shader,
 R_SortDrawSurfs
 =================
 */
-void R_SortDrawSurfs( drawSurf_t *drawSurfs, int numDrawSurfs ) {
+static void R_SortDrawSurfs( drawSurf_t *drawSurfs, int numDrawSurfs ) {
 	shader_t		*shader;
 	int				fogNum;
 	int				entityNum;
@@ -1633,7 +1633,7 @@ static void R_AddEntitySurface (int entityNum)
 R_AddEntitySurfaces
 =============
 */
-void R_AddEntitySurfaces (void) {
+static void R_AddEntitySurfaces (void) {
 	int i;
 
 	if ( !r_drawentities->integer ) {
@@ -1650,7 +1650,7 @@ void R_AddEntitySurfaces (void) {
 R_GenerateDrawSurfs
 ====================
 */
-void R_GenerateDrawSurfs( void ) {
+static void R_GenerateDrawSurfs( void ) {
 	R_AddWorldSurfaces ();
 
 	R_AddPolygonSurfaces();
@@ -1678,7 +1678,7 @@ void R_GenerateDrawSurfs( void ) {
 R_DebugPolygon
 ================
 */
-void R_DebugPolygon( int color, int numPoints, float *points ) {
+static void R_DebugPolygon( int color, int numPoints, float *points ) {
 	// FIXME: implement this
 #if 0
 	int		i;
@@ -1714,7 +1714,7 @@ R_DebugGraphics
 Visualization aid for movement clipping debugging
 ====================
 */
-void R_DebugGraphics( void ) {
+static void R_DebugGraphics( void ) {
 	if ( tr.refdef.rdflags & RDF_NOWORLDMODEL ) {
 		return;
 	}

--- a/code/renderer2/tr_mesh.c
+++ b/code/renderer2/tr_mesh.c
@@ -243,7 +243,7 @@ R_ComputeFogNum
 
 =================
 */
-int R_ComputeFogNum( mdvModel_t *model, trRefEntity_t *ent ) {
+static int R_ComputeFogNum( mdvModel_t *model, trRefEntity_t *ent ) {
 	int				i, j;
 	fog_t			*fog;
 	mdvFrame_t		*mdvFrame;

--- a/code/renderer2/tr_model_iqm.c
+++ b/code/renderer2/tr_model_iqm.c
@@ -1173,7 +1173,7 @@ R_ComputeIQMFogNum
 
 =================
 */
-int R_ComputeIQMFogNum( iqmData_t *data, trRefEntity_t *ent ) {
+static int R_ComputeIQMFogNum( iqmData_t *data, trRefEntity_t *ent ) {
 	int			i, j;
 	fog_t			*fog;
 	const vec_t		*bounds;

--- a/code/renderer2/tr_scene.c
+++ b/code/renderer2/tr_scene.c
@@ -239,7 +239,7 @@ RE_AddDynamicLightToScene
 
 =====================
 */
-void RE_AddDynamicLightToScene( const vec3_t org, float intensity, float r, float g, float b, int additive ) {
+static void RE_AddDynamicLightToScene( const vec3_t org, float intensity, float r, float g, float b, int additive ) {
 	dlight_t	*dl;
 
 	if ( !tr.registered ) {

--- a/code/renderer2/tr_shade_calc.c
+++ b/code/renderer2/tr_shade_calc.c
@@ -107,7 +107,7 @@ RB_CalcDeformVertexes
 
 ========================
 */
-void RB_CalcDeformVertexes( deformStage_t *ds )
+static void RB_CalcDeformVertexes( deformStage_t *ds )
 {
 	int i;
 	vec3_t	offset;
@@ -158,7 +158,7 @@ RB_CalcDeformNormals
 Wiggle the normals for wavy environment mapping
 =========================
 */
-void RB_CalcDeformNormals( deformStage_t *ds ) {
+static void RB_CalcDeformNormals( deformStage_t *ds ) {
 	int i;
 	float	scale;
 	float	*xyz = ( float * ) tess.xyz;
@@ -196,7 +196,7 @@ RB_CalcBulgeVertexes
 
 ========================
 */
-void RB_CalcBulgeVertexes( deformStage_t *ds ) {
+static void RB_CalcBulgeVertexes( deformStage_t *ds ) {
 	int i;
 	const float *st = ( const float * ) tess.texCoords[0];
 	float		*xyz = ( float * ) tess.xyz;
@@ -230,7 +230,7 @@ RB_CalcMoveVertexes
 A deformation that can move an entire surface along a wave path
 ======================
 */
-void RB_CalcMoveVertexes( deformStage_t *ds ) {
+static void RB_CalcMoveVertexes( deformStage_t *ds ) {
 	int			i;
 	float		*xyz;
 	float		*table;
@@ -260,7 +260,7 @@ DeformText
 Change a polygon into a bunch of text polygons
 =============
 */
-void DeformText( const char *text ) {
+static void DeformText( const char *text ) {
 	int		i;
 	vec3_t	origin, width, height;
 	int		len;
@@ -425,7 +425,7 @@ Autosprite2Deform
 Autosprite2 will pivot a rectangular quad along the center of its long axis
 =====================
 */
-unsigned int edgeVerts[6][2] = {
+static unsigned int edgeVerts[6][2] = {
 	{ 0, 1 },
 	{ 0, 2 },
 	{ 0, 3 },

--- a/code/renderer2/tr_sky.c
+++ b/code/renderer2/tr_sky.c
@@ -257,7 +257,7 @@ static void ClearSkyBox (void) {
 RB_ClipSkyPolygons
 ================
 */
-void RB_ClipSkyPolygons( shaderCommands_t *input )
+static void RB_ClipSkyPolygons( shaderCommands_t *input )
 {
 	vec3_t		p[5];	// need one extra point for clipping
 	int			i, j;
@@ -692,7 +692,7 @@ static void FillCloudBox( const shader_t *shader, int stage )
 /*
 ** R_BuildCloudData
 */
-void R_BuildCloudData( shaderCommands_t *input )
+static void R_BuildCloudData( shaderCommands_t *input )
 {
 	int			i;
 	shader_t	*shader;

--- a/code/renderer2/tr_surface.c
+++ b/code/renderer2/tr_surface.c
@@ -63,7 +63,7 @@ void RB_CheckOverflow( int verts, int indexes ) {
 	RB_BeginSurface(tess.shader, tess.fogNum, tess.cubemapIndex );
 }
 
-void RB_CheckVao(vao_t *vao)
+static void RB_CheckVao(vao_t *vao)
 {
 	if (vao != glState.currentVao)
 	{
@@ -1205,7 +1205,7 @@ static void RB_SurfaceFlare(srfFlare_t *surf)
 		RB_AddFlare(surf, tess.fogNum, surf->origin, surf->color, surf->normal);
 }
 
-void RB_SurfaceVaoMdvMesh(srfVaoMdvMesh_t * surface)
+static void RB_SurfaceVaoMdvMesh(srfVaoMdvMesh_t * surface)
 {
 	//mdvModel_t     *mdvModel;
 	//mdvSurface_t   *mdvSurface;

--- a/code/renderercommon/tr_font.c
+++ b/code/renderercommon/tr_font.c
@@ -144,7 +144,7 @@ FT_Bitmap *R_RenderGlyph(FT_GlyphSlot glyph, glyphInfo_t* glyphOut) {
 	return NULL;
 }
 
-void WriteTGA (char *filename, byte *data, int width, int height) {
+static void WriteTGA (char *filename, byte *data, int width, int height) {
 	byte			*buffer;
 	int				i, c;
 	int             row;
@@ -306,7 +306,7 @@ static glyphInfo_t *RE_ConstructGlyphInfo(unsigned char *imageOut, int *xOut, in
 static int fdOffset;
 static byte	*fdFile;
 
-int readInt( void ) {
+static int readInt( void ) {
 	int i = ((unsigned int)fdFile[fdOffset] | ((unsigned int)fdFile[fdOffset+1]<<8) | ((unsigned int)fdFile[fdOffset+2]<<16) | ((unsigned int)fdFile[fdOffset+3]<<24));
 	fdOffset += 4;
 	return i;

--- a/code/renderervk/tr_font.c
+++ b/code/renderervk/tr_font.c
@@ -143,7 +143,7 @@ FT_Bitmap *R_RenderGlyph(FT_GlyphSlot glyph, glyphInfo_t* glyphOut) {
 	return NULL;
 }
 
-void WriteTGA (char *filename, byte *data, int width, int height) {
+static void WriteTGA (char *filename, byte *data, int width, int height) {
 	byte			*buffer;
 	int				i, c;
 	int             row;

--- a/code/renderervk/tr_init.c
+++ b/code/renderervk/tr_init.c
@@ -274,7 +274,7 @@ void QDECL Com_Printf( const char *fmt, ... )
 /*
 ** R_HaveExtension
 */
-qboolean R_HaveExtension( const char *ext )
+static qboolean R_HaveExtension( const char *ext )
 {
 	const char *ptr = Q_stristr( gl_extensions, ext );
 	if (ptr == NULL)

--- a/code/renderervk/tr_local.h
+++ b/code/renderervk/tr_local.h
@@ -1410,7 +1410,7 @@ void R_AddLitSurf( surfaceType_t *surface, shader_t *shader, int fogIndex );
 #define	CULL_IN		0		// completely unclipped
 #define	CULL_CLIP	1		// clipped by one or more planes
 #define	CULL_OUT	2		// completely outside the clipping planes
-void R_LocalNormalToWorld( const vec3_t local, vec3_t world );
+
 void R_LocalPointToWorld( const vec3_t local, vec3_t world );
 int R_CullLocalBox( const vec3_t bounds[2] );
 int R_CullPointAndRadius( const vec3_t origin, float radius );
@@ -1688,11 +1688,9 @@ SKIES
 ============================================================
 */
 
-void R_BuildCloudData( shaderCommands_t *shader );
 void R_InitSkyTexCoords( float cloudLayerHeight );
 void R_DrawSkyBox( shaderCommands_t *shader );
 void RB_DrawSun( float scale, shader_t *shader );
-void RB_ClipSkyPolygons( shaderCommands_t *shader );
 
 /*
 ============================================================
@@ -1958,8 +1956,6 @@ void RE_ThrottleBackend( void );
 qboolean RE_CanMinimize( void );
 const glconfig_t *RE_GetConfig( void );
 void RE_VertexLighting( qboolean allowed );
-
-qboolean R_HaveExtension( const char *ext );
 
 #ifndef USE_VULKAN
 #define GLE( ret, name, ... ) extern ret ( APIENTRY * q##name )( __VA_ARGS__ );

--- a/code/renderervk/tr_main.c
+++ b/code/renderervk/tr_main.c
@@ -206,7 +206,7 @@ int R_CullDlight( const dlight_t* dl )
 R_LocalNormalToWorld
 =================
 */
-void R_LocalNormalToWorld( const vec3_t local, vec3_t world ) {
+static void R_LocalNormalToWorld( const vec3_t local, vec3_t world ) {
 	world[0] = local[0] * tr.or.axis[0][0] + local[1] * tr.or.axis[1][0] + local[2] * tr.or.axis[2][0];
 	world[1] = local[0] * tr.or.axis[0][1] + local[1] * tr.or.axis[1][1] + local[2] * tr.or.axis[2][1];
 	world[2] = local[0] * tr.or.axis[0][2] + local[1] * tr.or.axis[1][2] + local[2] * tr.or.axis[2][2];
@@ -1581,7 +1581,7 @@ static void R_SortDrawSurfs( drawSurf_t *drawSurfs, int numDrawSurfs ) {
 R_AddEntitySurfaces
 =============
 */
-void R_AddEntitySurfaces( void ) {
+static void R_AddEntitySurfaces( void ) {
 	trRefEntity_t	*ent;
 	shader_t		*shader;
 
@@ -1673,7 +1673,7 @@ void R_AddEntitySurfaces( void ) {
 R_GenerateDrawSurfs
 ====================
 */
-void R_GenerateDrawSurfs( void ) {
+static void R_GenerateDrawSurfs( void ) {
 	R_AddWorldSurfaces ();
 
 	R_AddPolygonSurfaces();

--- a/code/renderervk/tr_marks.c
+++ b/code/renderervk/tr_marks.c
@@ -133,7 +133,7 @@ R_BoxSurfaces_r
 
 =================
 */
-void R_BoxSurfaces_r(mnode_t *node, vec3_t mins, vec3_t maxs, surfaceType_t **list, int listsize, int *listlength, vec3_t dir) {
+static void R_BoxSurfaces_r(mnode_t *node, vec3_t mins, vec3_t maxs, surfaceType_t **list, int listsize, int *listlength, vec3_t dir) {
 
 	int			s, c;
 	msurface_t	*surf, **mark;
@@ -195,7 +195,7 @@ R_AddMarkFragments
 
 =================
 */
-void R_AddMarkFragments(int numClipPoints, vec3_t clipPoints[2][MAX_VERTS_ON_POLY],
+static void R_AddMarkFragments(int numClipPoints, vec3_t clipPoints[2][MAX_VERTS_ON_POLY],
 				   int numPlanes, vec3_t *normals, float *dists,
 				   int maxPoints, vec3_t pointBuffer,
 				   int maxFragments, markFragment_t *fragmentBuffer,

--- a/code/renderervk/tr_mesh.c
+++ b/code/renderervk/tr_mesh.c
@@ -242,7 +242,7 @@ int R_ComputeLOD( trRefEntity_t *ent ) {
 R_ComputeFogNum
 =================
 */
-int R_ComputeFogNum( md3Header_t *header, trRefEntity_t *ent ) {
+static int R_ComputeFogNum( md3Header_t *header, trRefEntity_t *ent ) {
 	int				i, j;
 	fog_t			*fog;
 	md3Frame_t		*md3Frame;

--- a/code/renderervk/tr_model.c
+++ b/code/renderervk/tr_model.c
@@ -33,7 +33,7 @@ static qboolean R_LoadMDR(model_t *mod, void *buffer, int filesize, const char *
 R_RegisterMD3
 ====================
 */
-qhandle_t R_RegisterMD3(const char *name, model_t *mod)
+static qhandle_t R_RegisterMD3(const char *name, model_t *mod)
 {
 	union {
 		uint32_t *u;
@@ -119,7 +119,7 @@ qhandle_t R_RegisterMD3(const char *name, model_t *mod)
 R_RegisterMDR
 ====================
 */
-qhandle_t R_RegisterMDR(const char *name, model_t *mod)
+static qhandle_t R_RegisterMDR(const char *name, model_t *mod)
 {
 	union {
 		uint32_t *u;
@@ -163,7 +163,7 @@ qhandle_t R_RegisterMDR(const char *name, model_t *mod)
 R_RegisterIQM
 ====================
 */
-qhandle_t R_RegisterIQM(const char *name, model_t *mod)
+static qhandle_t R_RegisterIQM(const char *name, model_t *mod)
 {
 	union {
 		unsigned *u;
@@ -1041,7 +1041,7 @@ static md3Tag_t *R_GetTag( md3Header_t *mod, int frame, const char *tagName ) {
 	return NULL;
 }
 
-md3Tag_t *R_GetAnimTag( mdrHeader_t *mod, int framenum, const char *tagName, md3Tag_t * dest) 
+static md3Tag_t *R_GetAnimTag( mdrHeader_t *mod, int framenum, const char *tagName, md3Tag_t * dest) 
 {
 	int				i, j, k;
 	int				frameSize;

--- a/code/renderervk/tr_model_iqm.c
+++ b/code/renderervk/tr_model_iqm.c
@@ -1006,7 +1006,7 @@ R_ComputeIQMFogNum
 
 =================
 */
-int R_ComputeIQMFogNum( iqmData_t *data, trRefEntity_t *ent ) {
+static int R_ComputeIQMFogNum( iqmData_t *data, trRefEntity_t *ent ) {
 	int			i, j;
 	fog_t			*fog;
 	const vec_t		*bounds;

--- a/code/renderervk/tr_scene.c
+++ b/code/renderervk/tr_scene.c
@@ -243,7 +243,7 @@ void RE_AddRefEntityToScene( const refEntity_t *ent, qboolean intShaderTime ) {
 RE_AddDynamicLightToScene
 =====================
 */
-void RE_AddDynamicLightToScene( const vec3_t org, float intensity, float r, float g, float b, int additive ) {
+static void RE_AddDynamicLightToScene( const vec3_t org, float intensity, float r, float g, float b, int additive ) {
 	dlight_t	*dl;
 
 	if ( !tr.registered ) {

--- a/code/renderervk/tr_shade_calc.c
+++ b/code/renderervk/tr_shade_calc.c
@@ -117,7 +117,7 @@ DEFORMATIONS
 RB_CalcDeformVertexes
 ========================
 */
-void RB_CalcDeformVertexes( deformStage_t *ds )
+static void RB_CalcDeformVertexes( deformStage_t *ds )
 {
 	int i;
 	vec3_t	offset;
@@ -169,7 +169,7 @@ RB_CalcDeformNormals
 Wiggle the normals for wavy environment mapping
 =========================
 */
-void RB_CalcDeformNormals( deformStage_t *ds ) {
+static void RB_CalcDeformNormals( deformStage_t *ds ) {
 	int i;
 	float	scale;
 	float	*xyz = ( float * ) tess.xyz;
@@ -201,7 +201,7 @@ void RB_CalcDeformNormals( deformStage_t *ds ) {
 RB_CalcBulgeVertexes
 ========================
 */
-void RB_CalcBulgeVertexes( deformStage_t *ds ) {
+static void RB_CalcBulgeVertexes( deformStage_t *ds ) {
 	int i;
 	const float *st = ( const float * ) tess.texCoords[0][0];
 	float		*xyz = ( float * ) tess.xyz;
@@ -232,7 +232,7 @@ RB_CalcMoveVertexes
 A deformation that can move an entire surface along a wave path
 ======================
 */
-void RB_CalcMoveVertexes( deformStage_t *ds ) {
+static void RB_CalcMoveVertexes( deformStage_t *ds ) {
 	int			i;
 	float		*xyz;
 	float		*table;
@@ -262,7 +262,7 @@ DeformText
 Change a polygon into a bunch of text polygons
 =============
 */
-void DeformText( const char *text ) {
+static void DeformText( const char *text ) {
 	int		i;
 	vec3_t	origin, width, height;
 	int		len;

--- a/code/renderervk/tr_shader.c
+++ b/code/renderervk/tr_shader.c
@@ -1360,7 +1360,7 @@ static void ParseSkyParms( const char **text ) {
 ParseSort
 =================
 */
-void ParseSort( const char **text ) {
+static void ParseSort( const char **text ) {
 	char	*token;
 
 	token = COM_ParseExt( text, qfalse );

--- a/code/renderervk/tr_sky.c
+++ b/code/renderervk/tr_sky.c
@@ -257,7 +257,7 @@ static void ClearSkyBox (void) {
 RB_ClipSkyPolygons
 ================
 */
-void RB_ClipSkyPolygons( shaderCommands_t *input )
+static void RB_ClipSkyPolygons( shaderCommands_t *input )
 {
 	vec3_t		p[5];	// need one extra point for clipping
 	int			i, j;
@@ -632,7 +632,7 @@ static void FillCloudBox( void )
 /*
 ** R_BuildCloudData
 */
-void R_BuildCloudData( shaderCommands_t *input )
+static void R_BuildCloudData( shaderCommands_t *input )
 {
 	const shader_t *shader;
 

--- a/code/server/server.h
+++ b/code/server/server.h
@@ -320,7 +320,6 @@ void SVC_RateRestoreBurstAddress( const netadr_t *from, int burst, int period );
 void SVC_RateRestoreToxicAddress( const netadr_t *from, int burst, int period );
 void SVC_RateDropAddress( const netadr_t *from, int burst, int period );
 
-void SV_FinalMessage( const char *message );
 void QDECL SV_SendServerCommand( client_t *cl, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 void SV_AddOperatorCommands( void );

--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -801,7 +801,7 @@ not just stuck on the outgoing message list, because the server is going
 to totally exit after returning from this function.
 ==================
 */
-void SV_FinalMessage( const char *message ) {
+static void SV_FinalMessage( const char *message ) {
 	int			i, j;
 	client_t	*cl;
 

--- a/code/server/sv_net_chan.c
+++ b/code/server/sv_net_chan.c
@@ -154,7 +154,7 @@ void SV_Netchan_FreeQueue(client_t *client)
 SV_Netchan_TransmitNextInQueue
 =================
 */
-void SV_Netchan_TransmitNextInQueue(client_t *client)
+static void SV_Netchan_TransmitNextInQueue(client_t *client)
 {
 	netchan_buffer_t *netbuf;
 		

--- a/code/server/sv_world.c
+++ b/code/server/sv_world.c
@@ -71,8 +71,8 @@ typedef struct worldSector_s {
 #define	AREA_DEPTH	4
 #define	AREA_NODES	64
 
-worldSector_t	sv_worldSectors[AREA_NODES];
-int			sv_numworldSectors;
+static worldSector_t	sv_worldSectors[AREA_NODES];
+static int			sv_numworldSectors;
 
 
 /*


### PR DESCRIPTION
# Define static functions as such.
Following your 'guidelines' and previous work to define everything that is static as such, I looked for other functions that are static.
So I made a pull request marked as draft, that defines already static functions as 'static'. Mainly the botlib is affected, though the other modules are affected as well.

## ***What is changing:***
  + 'static' is added to functions that are static, corresponding deletions are made to associated header files.
## ***Notes:***
  + As far as the botlib is concerned:

     There are really much more functions inside the botlib that are static but NOT defined as such. I leave them untouched so far for three reasons.

   1. As soon as unused functions are defined as static (some) compiler will throw out a warning these functions are defined but not used. If you will apply this pull request, I will expand this draft and continue with removing this functions, if you want.
   2. Some functions will not get removed or declared as static ever because other engines will use them, though actually they are still unused, but this way we keep maximum compatibility with future projects based on Q3e (e.g.: RtCW).
   3. A few functions will NOT defined as static although they are, because the BSPC tool will need them too. Which isn't a problem for Q3a at the moment because the BSPC tool isn't added. I found this when working on other projects like Spearmint (where the BSPC tool is part of the source code), also WoP where I opened a ticket for such a situation (https://github.com/PadWorld-Entertainment/worldofpadman/issues/53).
  +  As always, feel free to apply or skip it.
