### PR TITLE
Clean up unused (static) botlib functions V1.

### DIFF
--- a/code/botlib/be_aas_bsp.h
+++ b/code/botlib/be_aas_bsp.h
@@ -66,6 +66,7 @@ bsp_trace_t AAS_Trace(	vec3_t start,
 								int contentmask);
 //returns the contents at the given point
 int AAS_PointContents(vec3_t point);
+#if 0
 //returns true when p2 is in the PVS of p1
 qboolean AAS_inPVS(vec3_t p1, vec3_t p2);
 //returns true when p2 is in the PHS of p1
@@ -74,6 +75,7 @@ qboolean AAS_inPHS(vec3_t p1, vec3_t p2);
 qboolean AAS_AreasConnected(int area1, int area2);
 //creates a list with entities totally or partly within the given box
 int AAS_BoxEntities(vec3_t absmins, vec3_t absmaxs, int *list, int maxcount);
+#endif
 //gets the mins, maxs and origin of a BSP model
 void AAS_BSPModelMinsMaxsOrigin(int modelnum, vec3_t angles, vec3_t mins, vec3_t maxs, vec3_t origin);
 //handle to the next bsp entity

--- a/code/botlib/be_aas_bspq3.c
+++ b/code/botlib/be_aas_bspq3.c
@@ -49,14 +49,14 @@ extern botlib_import_t botimport;
 //#define DEG2RAD( a ) (( a * M_PI ) / 180.0F)
 
 #define MAX_BSPENTITIES		2048
-
+#if 0
 typedef struct rgb_s
 {
 	int red;
 	int green;
 	int blue;
 } rgb_t;
-
+#endif
 //bsp entity epair
 typedef struct bsp_epair_s
 {
@@ -123,7 +123,7 @@ cname_t contentnames[] =
 	{CONTENTS_LADDER,"CONTENTS_LADDER"},
 	{0, 0}
 };
-
+#if 0
 void PrintContents(int contents)
 {
 	int i;
@@ -136,7 +136,7 @@ void PrintContents(int contents)
 		} //end if
 	} //end for
 } //end of the function PrintContents
-
+#endif
 #endif // BSP_DEBUG
 //===========================================================================
 // traces axial boxes of any size through the world
@@ -182,6 +182,7 @@ qboolean AAS_EntityCollision(int entnum,
 	} //end if
 	return qfalse;
 } //end of the function AAS_EntityCollision
+#if 0
 //===========================================================================
 // returns true if in Potentially Hearable Set
 //
@@ -204,6 +205,7 @@ qboolean AAS_inPHS(vec3_t p1, vec3_t p2)
 {
 	return qtrue;
 } //end of the function AAS_inPHS
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -234,6 +236,7 @@ bsp_link_t *AAS_BSPLinkEntity(vec3_t absmins, vec3_t absmaxs, int entnum, int mo
 {
 	return NULL;
 } //end of the function AAS_BSPLinkEntity
+#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -244,6 +247,7 @@ int AAS_BoxEntities(vec3_t absmins, vec3_t absmaxs, int *list, int maxcount)
 {
 	return 0;
 } //end of the function AAS_BoxEntities
+#endif
 //===========================================================================
 //
 // Parameter:			-
@@ -368,8 +372,12 @@ static void AAS_FreeBSPEntities(void)
 	} //end for
 	bspworld.numentities = 0;
 } //end of the function AAS_FreeBSPEntities
-
-
+//===========================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//===========================================================================
 static void AAS_ParseBSPEntities(void)
 {
 	script_t *script;
@@ -435,15 +443,23 @@ static void AAS_ParseBSPEntities(void)
 	} //end while
 	FreeScript(script);
 } //end of the function AAS_ParseBSPEntities
-
-
 #if 0
+//===========================================================================
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//===========================================================================
 static int AAS_BSPTraceLight(vec3_t start, vec3_t end, vec3_t endpos, int *red, int *green, int *blue)
 {
 	return 0;
 #endif
-
-
+//===========================================================================
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//===========================================================================
 void AAS_DumpBSPData(void)
 {
 	AAS_FreeBSPEntities();
@@ -451,14 +467,16 @@ void AAS_DumpBSPData(void)
 	if (bspworld.dentdata) FreeMemory(bspworld.dentdata);
 	bspworld.dentdata = NULL;
 	bspworld.entdatasize = 0;
-
+	//
 	bspworld.loaded = qfalse;
 	Com_Memset( &bspworld, 0, sizeof(bspworld) );
-}
-
-
+} //end of the function AAS_DumpBSPData
 //===========================================================================
 // load a .bsp file
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
 //===========================================================================
 int AAS_LoadBSPFile(void)
 {
@@ -469,5 +487,5 @@ int AAS_LoadBSPFile(void)
 	AAS_ParseBSPEntities();
 	bspworld.loaded = qtrue;
 	return BLERR_NOERROR;
-}
+} //end of the function AAS_LoadBSPFile
 

--- a/code/botlib/be_aas_cluster.c
+++ b/code/botlib/be_aas_cluster.c
@@ -76,6 +76,7 @@ static void AAS_RemoveClusterAreas(void)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
+#if 0
 void AAS_ClearCluster(int clusternum)
 {
 	int i;
@@ -110,6 +111,7 @@ void AAS_RemovePortalsClusterReference(int clusternum)
 		} //end if
 	} //end for
 } //end of the function AAS_RemovePortalsClusterReference
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -280,13 +282,14 @@ static int AAS_FloodClusterAreasUsingReachabilities(int clusternum)
 	} //end for
 	return qtrue;
 } //end of the function AAS_FloodClusterAreasUsingReachabilities
+#if 0
 //===========================================================================
 //
 // Parameter:			-
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_NumberClusterPortals(int clusternum)
+static void AAS_NumberClusterPortals(int clusternum)
 {
 	int i, portalnum;
 	aas_cluster_t *cluster;
@@ -307,6 +310,7 @@ void AAS_NumberClusterPortals(int clusternum)
 		} //end else
 	} //end for
 } //end of the function AAS_NumberClusterPortals
+#endif
 //===========================================================================
 //
 // Parameter:			-
@@ -929,6 +933,7 @@ static void AAS_FindPossiblePortals(void)
 	} //end for
 	botimport.Print(PRT_MESSAGE, "\r%6d possible portal areas\n", numpossibleportals);
 } //end of the function AAS_FindPossiblePortals
+#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -944,8 +949,6 @@ void AAS_RemoveAllPortals(void)
 		aasworld.areasettings[i].contents &= ~AREACONTENTS_CLUSTERPORTAL;
 	} //end for
 } //end of the function AAS_RemoveAllPortals
-
-#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -1055,7 +1058,6 @@ void AAS_FloodClusterReachabilities(int clusternum)
 		} //end for
 	} //end for
 } //end of the function AAS_FloodClusterReachabilities
-
 //===========================================================================
 //
 // Parameter:				-
@@ -1128,14 +1130,12 @@ void AAS_RemoveNotClusterClosingPortals(void)
 	} //end for
 	botimport.Print(PRT_MESSAGE, "\r%6d non closing portals removed\n", nonclosingportals);
 } //end of the function AAS_RemoveNotClusterClosingPortals
-
 //===========================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-
 void AAS_RemoveNotClusterClosingPortals(void)
 {
 	int i, j, facenum, otherareanum, nonclosingportals, numseperatedclusters;
@@ -1202,14 +1202,12 @@ void AAS_RemoveNotClusterClosingPortals(void)
 	} //end for
 	botimport.Print(PRT_MESSAGE, "\r%6d non closing portals removed\n", nonclosingportals);
 } //end of the function AAS_RemoveNotClusterClosingPortals
-
 //===========================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-
 void AAS_AddTeleporterPortals(void)
 {
 	int j, area2num, facenum, otherareanum;
@@ -1340,7 +1338,6 @@ void AAS_AddTeleporterPortals(void)
 	} //end for
 	AAS_FreeBSPEntities(entities);
 } //end of the function AAS_AddTeleporterPortals
-
 //===========================================================================
 //
 // Parameter:				-
@@ -1361,9 +1358,7 @@ void AAS_AddTeleporterPortals(void)
 		} //end for
 	} //end for
 } //end of the function AAS_AddTeleporterPortals
-
 #endif
-
 //===========================================================================
 //
 // Parameter:				-

--- a/code/botlib/be_aas_debug.c
+++ b/code/botlib/be_aas_debug.c
@@ -708,7 +708,7 @@ void AAS_ShowReachableAreas(int areanum)
 		botimport.Print(PRT_MESSAGE, "\n");
 	} //end if
 	AAS_ShowReachability(&reach);
-} //end of the function ShowReachableAreas
+} //end of the function AAS_ShowReachableAreas
 
 static void AAS_FloodAreas_r(int areanum, int cluster, int *done)
 {

--- a/code/botlib/be_aas_entity.c
+++ b/code/botlib/be_aas_entity.c
@@ -186,6 +186,7 @@ void AAS_EntityInfo(int entnum, aas_entityinfo_t *info)
 
 	Com_Memcpy(info, &aasworld.entities[entnum].i, sizeof(aas_entityinfo_t));
 } //end of the function AAS_EntityInfo
+#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -203,6 +204,7 @@ void AAS_EntityOrigin(int entnum, vec3_t origin)
 
 	VectorCopy(aasworld.entities[entnum].i.origin, origin);
 } //end of the function AAS_EntityOrigin
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -277,6 +279,7 @@ int AAS_OriginOfMoverWithModelNum(int modelnum, vec3_t origin)
 	} //end for
 	return qfalse;
 } //end of the function AAS_OriginOfMoverWithModelNum
+#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -317,6 +320,7 @@ void AAS_EntityBSPData(int entnum, bsp_entdata_t *entdata)
 	entdata->solid = ent->i.solid;
 	entdata->modelnum = ent->i.modelindex - 1;
 } //end of the function AAS_EntityBSPData
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -370,6 +374,7 @@ void AAS_UnlinkInvalidEntities(void)
 		} //end for
 	} //end for
 } //end of the function AAS_UnlinkInvalidEntities
+#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -418,6 +423,7 @@ int AAS_BestReachableEntityArea(int entnum)
 	ent = &aasworld.entities[entnum];
 	return AAS_BestReachableLinkArea(ent->areas);
 } //end of the function AAS_BestReachableEntityArea
+#endif
 //===========================================================================
 //
 // Parameter:			-

--- a/code/botlib/be_aas_entity.h
+++ b/code/botlib/be_aas_entity.h
@@ -39,23 +39,30 @@ void AAS_ResetEntityLinks(void);
 //updates an entity
 int AAS_UpdateEntity(int ent, bot_entitystate_t *state);
 //gives the entity data used for collision detection
+#if 0
 void AAS_EntityBSPData(int entnum, bsp_entdata_t *entdata);
+#endif
 #endif //AASINTERN
-
+#if 0
 //returns the size of the entity bounding box in mins and maxs
 void AAS_EntitySize(int entnum, vec3_t mins, vec3_t maxs);
+#endif
 //returns the BSP model number of the entity
 int AAS_EntityModelNum(int entnum);
 //returns the origin of an entity with the given model number
 int AAS_OriginOfMoverWithModelNum(int modelnum, vec3_t origin);
+#if 0
 //returns the best reachable area the entity is situated in
 int AAS_BestReachableEntityArea(int entnum);
+#endif
 //returns the info of the given entity
 void AAS_EntityInfo(int entnum, aas_entityinfo_t *info);
 //returns the next entity
 int AAS_NextEntity(int entnum);
+#if 0
 //returns the origin of the entity
 void AAS_EntityOrigin(int entnum, vec3_t origin);
+#endif
 //returns the entity type
 int AAS_EntityType(int entnum);
 //returns the model index of the entity

--- a/code/botlib/be_aas_main.c
+++ b/code/botlib/be_aas_main.c
@@ -242,7 +242,7 @@ static int AAS_LoadFiles(const char *mapname)
 	return BLERR_NOERROR;
 } //end of the function AAS_LoadFiles
 //===========================================================================
-// called everytime a map changes
+// called every time a map changes
 //
 // Parameter:				-
 // Returns:					-

--- a/code/botlib/be_aas_move.c
+++ b/code/botlib/be_aas_move.c
@@ -405,8 +405,6 @@ static void AAS_ApplyFriction(vec3_t vel, float friction, float stopspeed,
 		vel[1] *= newspeed;
 	} //end if
 } //end of the function AAS_ApplyFriction
-
-
 //===========================================================================
 //
 // Parameter:			-
@@ -476,8 +474,6 @@ static qboolean AAS_ClipToBBox( aas_trace_t *trace, const vec3_t start, const ve
 	} //end if
 	return qfalse;
 } //end of the function AAS_ClipToBBox
-
-
 //===========================================================================
 // predicts the movement
 // assumes regular bounding box sizes
@@ -980,8 +976,6 @@ static int AAS_ClientMovementPrediction( aas_clientmove_t *move,
 	//
 	return qtrue;
 } //end of the function AAS_ClientMovementPrediction
-
-
 //===========================================================================
 //
 // Parameter:			-
@@ -1003,8 +997,6 @@ int AAS_PredictClientMovement(struct aas_clientmove_s *move,
 										frametime, stopevent, stopareanum,
 										mins, maxs, visualize);
 } //end of the function AAS_PredictClientMovement
-
-
 //===========================================================================
 //
 // Parameter:			-
@@ -1024,6 +1016,7 @@ int AAS_ClientMovementHitBBox(struct aas_clientmove_s *move,
 										frametime, SE_HITBOUNDINGBOX, 0,
 										mins, maxs, visualize);
 } //end of the function AAS_ClientMovementHitBBox
+#if 0
 //===========================================================================
 //
 // Parameter:			-
@@ -1048,6 +1041,7 @@ void AAS_TestMovementPrediction(int entnum, vec3_t origin, vec3_t dir)
 		botimport.Print(PRT_MESSAGE, "leave ground\n");
 	} //end if
 } //end of the function TestMovementPrediction
+#endif
 //===========================================================================
 // calculates the horizontal velocity needed to perform a jump from start
 // to end

--- a/code/botlib/be_aas_reach.c
+++ b/code/botlib/be_aas_reach.c
@@ -67,7 +67,7 @@ static int reach_equalfloor;	//walk on floors with equal height
 static int reach_step;			//step up
 static int reach_walk;			//walk of step
 static int reach_barrier;		//jump up to a barrier
-static int reach_waterjump;	//jump out of water
+static int reach_waterjump;		//jump out of water
 static int reach_walkoffledge;	//walk of a ledge
 static int reach_jump;			//jump
 static int reach_ladder;		//climb or descent a ladder
@@ -75,11 +75,13 @@ static int reach_teleport;		//teleport
 static int reach_elevator;		//use an elevator
 static int reach_funcbob;		//use a func bob
 static int reach_grapple;		//grapple hook
-int reach_doublejump;	//double jump
-int reach_rampjump;		//ramp jump
-int reach_strafejump;	//strafe jump (just normal jump but further)
+#if 0
+static int reach_doublejump;	//double jump
+static int reach_rampjump;		//ramp jump
+static int reach_strafejump;	//strafe jump (just normal jump but further)
+static int reach_bfgjump;		//bfg jump
+#endif
 static int reach_rocketjump;	//rocket jump
-int reach_bfgjump;		//bfg jump
 static int reach_jumppad;		//jump pads
 //if true grapple reachabilities are skipped
 int calcgrapplereach;
@@ -182,7 +184,7 @@ static float AAS_AreaVolume(int areanum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_BestReachableLinkArea(aas_link_t *areas)
+static int AAS_BestReachableLinkArea(aas_link_t *areas)
 {
 	aas_link_t *link;
 
@@ -764,6 +766,7 @@ int AAS_AreaDoNotEnter(int areanum)
 {
 	return (aasworld.areasettings[areanum].contents & AREACONTENTS_DONOTENTER);
 } //end of the function AAS_AreaDoNotEnter
+#if 0
 //===========================================================================
 // returns the time it takes perform a barrier jump
 //
@@ -771,10 +774,11 @@ int AAS_AreaDoNotEnter(int areanum)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-unsigned short int AAS_BarrierJumpTravelTime(void)
+static unsigned short int AAS_BarrierJumpTravelTime(void)
 {
 	return aassettings.phys_jumpvel / (aassettings.phys_gravity * 0.1);
 } //end op the function AAS_BarrierJumpTravelTime
+#endif
 //===========================================================================
 // returns true if there already exists a reachability from area1 to area2
 //
@@ -792,6 +796,7 @@ static qboolean AAS_ReachabilityExists(int area1num, int area2num)
 	} //end for
 	return qfalse;
 } //end of the function AAS_ReachabilityExists
+#if 0
 //===========================================================================
 // returns true if there is a solid just after the end point when going
 // from start to end
@@ -800,7 +805,7 @@ static qboolean AAS_ReachabilityExists(int area1num, int area2num)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_NearbySolidOrGap(vec3_t start, vec3_t end)
+static int AAS_NearbySolidOrGap(vec3_t start, vec3_t end)
 {
 	vec3_t dir, testpoint;
 	int areanum;
@@ -825,6 +830,7 @@ int AAS_NearbySolidOrGap(vec3_t start, vec3_t end)
 	} //end if
 	return qfalse;
 } //end of the function AAS_SolidGapTime
+#endif
 //===========================================================================
 // searches for swim reachabilities between adjacent areas
 //
@@ -3061,7 +3067,7 @@ static void AAS_Reachability_Elevator(void)
 					bottomorg[2] += 24;
 				} //end else
 				//look at adjacent areas around the top of the plat
-				//make larger steps to outside the plat everytime
+				//make larger steps to outside the plat every time
 				for (n = 0; n < 3; n++)
 				{
 					for (k = 0; k < 3; k++)

--- a/code/botlib/be_aas_reach.h
+++ b/code/botlib/be_aas_reach.h
@@ -34,8 +34,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 void AAS_InitReachability(void);
 //continue calculating the reachabilities
 int AAS_ContinueInitReachability(float time);
-//
+#if 0
 int AAS_BestReachableLinkArea(aas_link_t *areas);
+#endif
 #endif //AASINTERN
 
 //returns true if the are has reachabilities to other areas

--- a/code/botlib/be_aas_route.c
+++ b/code/botlib/be_aas_route.c
@@ -621,7 +621,7 @@ static void AAS_InitPortalMaxTravelTimes(void)
 // Changes Globals:		-
 //===========================================================================
 /*
-int AAS_FreeOldestCache(void)
+static int AAS_FreeOldestCache(void)
 {
 	int i, j, bestcluster, bestarea, freed;
 	float besttime;
@@ -1913,6 +1913,7 @@ int AAS_PredictRoute(struct aas_predictroute_s *route, int areanum, vec3_t origi
 		return qfalse;
 	return qtrue;
 } //end of the function AAS_PredictRoute
+#if 0
 //===========================================================================
 //
 // Parameter:			-
@@ -1923,6 +1924,7 @@ int AAS_BridgeWalkable(int areanum)
 {
 	return qfalse;
 } //end of the function AAS_BridgeWalkable
+#endif
 //===========================================================================
 //
 // Parameter:			-
@@ -2070,6 +2072,7 @@ static int AAS_AreaVisible(int srcarea, int destarea)
 {
 	return qfalse;
 } //end of the function AAS_AreaVisible
+#if 0
 //===========================================================================
 //
 // Parameter:			-
@@ -2084,6 +2087,7 @@ float DistancePointToLine(vec3_t v1, vec3_t v2, vec3_t point)
 	VectorSubtract(point, p2, vec);
 	return VectorLength(vec);
 } //end of the function DistancePointToLine
+#endif
 //===========================================================================
 //
 // Parameter:			-

--- a/code/botlib/be_aas_sample.c
+++ b/code/botlib/be_aas_sample.c
@@ -347,6 +347,7 @@ int AAS_PointPresenceType(vec3_t point)
 	if (!areanum) return PRESENCE_NONE;
 	return aasworld.areasettings[areanum].presencetype;
 } //end of the function AAS_PointPresenceType
+#if 0
 //===========================================================================
 // calculates the minimum distance between the origin of the box and the
 // given plane when both will collide on the given side of the plane
@@ -396,6 +397,7 @@ vec_t AAS_BoxOriginDistanceFromPlane(vec3_t normal, vec3_t mins, vec3_t maxs, in
 //	VectorNegate(normal, v2);
 	return DotProduct(v1, v2);
 } //end of the function AAS_BoxOriginDistanceFromPlane
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -1007,6 +1009,7 @@ qboolean AAS_PointInsideFace(int facenum, vec3_t point, float epsilon)
 	} //end for
 	return qtrue;
 } //end of the function AAS_PointInsideFace
+#if 0
 //===========================================================================
 // returns the ground face the given point is above in the given area
 //
@@ -1056,6 +1059,7 @@ void AAS_FacePlane(int facenum, vec3_t normal, float *dist)
 	VectorCopy(plane->normal, normal);
 	*dist = plane->dist;
 } //end of the function AAS_FacePlane
+#endif
 //===========================================================================
 // returns the face the trace end position is situated in
 //

--- a/code/botlib/be_aas_sample.h
+++ b/code/botlib/be_aas_sample.h
@@ -34,7 +34,9 @@ void AAS_InitAASLinkHeap(void);
 void AAS_InitAASLinkedEntities(void);
 void AAS_FreeAASLinkHeap(void);
 void AAS_FreeAASLinkedEntities(void);
+#if 0
 aas_face_t *AAS_AreaGroundFace(int areanum, vec3_t point);
+#endif
 aas_face_t *AAS_TraceEndFace(aas_trace_t *trace);
 aas_plane_t *AAS_PlaneFromNum(int planenum);
 aas_link_t *AAS_AASLinkEntity(vec3_t absmins, vec3_t absmaxs, int entnum);
@@ -63,6 +65,9 @@ int AAS_AreaInfo( int areanum, aas_areainfo_t *info );
 int AAS_PointAreaNum(vec3_t point);
 //
 int AAS_PointReachabilityAreaIndex( vec3_t point );
+#if 0
 //returns the plane the given face is in
 void AAS_FacePlane(int facenum, vec3_t normal, float *dist);
+#endif
+
 

--- a/code/botlib/be_ai_char.c
+++ b/code/botlib/be_ai_char.c
@@ -100,8 +100,12 @@ static bot_character_t *BotCharacterFromHandle(int handle)
 	} //end if
 	return botcharacters[handle];
 } //end of the function BotCharacterFromHandle
-
-
+//===========================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//===========================================================================
 static bot_character_t *BotReferenceHandle( int handle, int refmod )
 {
 	bot_character_t *ch;
@@ -119,8 +123,12 @@ static bot_character_t *BotReferenceHandle( int handle, int refmod )
 
 	return NULL;
 }
-
-
+//===========================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//===========================================================================
 static void BotDumpCharacter( const bot_character_t *ch )
 {
 	int i;
@@ -135,12 +143,10 @@ static void BotDumpCharacter( const bot_character_t *ch )
 			case CT_INTEGER: Log_Write(" %4d %d\n", i, ch->c[i].value.integer); break;
 			case CT_FLOAT: Log_Write(" %4d %f\n", i, ch->c[i].value._float); break;
 			case CT_STRING: Log_Write(" %4d %s\n", i, ch->c[i].value.string); break;
-		}
-	}
+		} //end case
+	} //end for
 	Log_Write("}\n");
-}
-
-
+} //end of the function BotDumpCharacter
 //========================================================================
 //
 // Parameter:			-
@@ -180,9 +186,13 @@ static void BotFreeCharacter2(int handle)
 	BotFreeCharacterStrings(botcharacters[handle]);
 	FreeMemory(botcharacters[handle]);
 	botcharacters[handle] = NULL;
-}
-
-
+} //end of the function BotFreeCharacter2
+//========================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//========================================================================
 void BotFreeCharacter( int handle )
 {
 	bot_character_t *ch;
@@ -205,9 +215,13 @@ void BotFreeCharacter( int handle )
 		return;
 
 	BotFreeCharacter2( handle );
-}
-
-
+} //end of the function BotFreeCharacter
+//========================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//========================================================================
 static int BotReleaseUnreferencedHandle( void )
 {
 	const bot_character_t *ch;
@@ -270,8 +284,6 @@ static void BotDefaultCharacteristics(bot_character_t *ch, bot_character_t *defa
 		} //end else if
 	} //end for
 } //end of the function BotDefaultCharacteristics
-
-
 //===========================================================================
 //
 // Parameter:			-

--- a/code/botlib/be_ai_chat.c
+++ b/code/botlib/be_ai_chat.c
@@ -474,8 +474,6 @@ void UnifyWhiteSpaces(char *string)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-
-
 int StringContains( const char *str1, const char *str2, int casesensitive )
 {
 	int len, i, j, index;
@@ -501,8 +499,12 @@ int StringContains( const char *str1, const char *str2, int casesensitive )
 	} //end for
 	return -1;
 } //end of the function StringContains
-
-
+//===========================================================================
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//===========================================================================
 static const char *StringContainsWord( const char *str1, const char *str2 )
 {
 	int len, i, j;
@@ -539,9 +541,13 @@ static const char *StringContainsWord( const char *str1, const char *str2 )
 	}
 
 	return NULL;
-}
-
-
+} //end of the function StringContainsWord
+//===========================================================================
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//===========================================================================
 static void StringReplaceWords( char *string, int size, const char *synonym, const char *replacement )
 {
 	char *str;
@@ -577,16 +583,16 @@ static void StringReplaceWords( char *string, int size, const char *synonym, con
 
 		//find the next synonym in the string
 		str = (char *) StringContainsWord( str + replen, synonym );
-	}
-}
-
-
+	} //end if
+} //end of the function StringReplaceWords
+#if 0
 //===========================================================================
+//
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotDumpSynonymList(bot_synonymlist_t *synlist)
+static void BotDumpSynonymList(bot_synonymlist_t *synlist)
 {
 	FILE *fp;
 	bot_synonymlist_t *syn;
@@ -605,6 +611,7 @@ void BotDumpSynonymList(bot_synonymlist_t *synlist)
 		fprintf(fp, "]\n");
 	} //end for
 } //end of the function BotDumpSynonymList
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -773,10 +780,12 @@ static bot_synonymlist_t *BotLoadSynonyms( const char *filename )
 	//
 	return synlist;
 } //end of the function BotLoadSynonyms
-
-
 //===========================================================================
 // replace all the synonyms in the string
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
 //===========================================================================
 void BotReplaceSynonyms( char *string, int size, unsigned long int context )
 {
@@ -791,11 +800,15 @@ void BotReplaceSynonyms( char *string, int size, unsigned long int context )
 		for ( synonym = syn->firstsynonym->next; synonym; synonym = synonym->next )
 		{
 			StringReplaceWords( string, size, synonym->string, syn->firstsynonym->string );
-		}
-	}
-}
-
-
+		} //end for
+	} //end for
+} //end of the function BotReplaceSynonyms
+//===========================================================================
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//===========================================================================
 static void BotReplaceWeightedSynonyms( char *string, int size, unsigned long int context )
 {
 	bot_synonymlist_t *syn;
@@ -828,11 +841,15 @@ static void BotReplaceWeightedSynonyms( char *string, int size, unsigned long in
 			if ( synonym == replacement )
 				continue;
 			StringReplaceWords( string, size, synonym->string, replacement->string );
-		}
-	}
-}
-
-
+		} //end for
+	} //end for
+} //end of the function BotReplaceWeightedSynonyms
+//===========================================================================
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//===========================================================================
 static void BotReplaceReplySynonyms( char *string, int size, unsigned long int context )
 {
 	char *str1, *replacement;
@@ -889,10 +906,14 @@ static void BotReplaceReplySynonyms( char *string, int size, unsigned long int c
 			str1++;
 		if ( *str1 == '\0' )
 			break;
-	}
-}
-
-
+	} //end while
+} //end of the function BotReplaceReplySynonyms
+//===========================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//===========================================================================
 static int BotLoadChatMessage( source_t *source, char *chatmessagestring, int size )
 {
 	char *ptr;
@@ -960,16 +981,15 @@ static int BotLoadChatMessage( source_t *source, char *chatmessagestring, int si
 	}
 
 	return qtrue;
-}
-
-
+} //end of the function BotLoadChatMessage
+#if 0
 //===========================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotDumpRandomStringList(bot_randomlist_t *randomlist)
+static void BotDumpRandomStringList(bot_randomlist_t *randomlist)
 {
 	FILE *fp;
 	bot_randomlist_t *random;
@@ -988,6 +1008,7 @@ void BotDumpRandomStringList(bot_randomlist_t *randomlist)
 		} //end for
 	} //end for
 } //end of the function BotDumpRandomStringList
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -1095,8 +1116,12 @@ static bot_randomlist_t *BotLoadRandomStrings( const char *filename )
 	//
 	return randomlist;
 } //end of the function BotLoadRandomStrings
-
-
+//===========================================================================
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//===========================================================================
 static char *RandomString( const char *name )
 {
 	const bot_randomlist_t *random;
@@ -1120,16 +1145,15 @@ static char *RandomString( const char *name )
 		}
 	}
 	return NULL;
-}
-
-
+} //end of the function RandomString
+#if 0
 //===========================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotDumpMatchTemplates(bot_matchtemplate_t *matches)
+static void BotDumpMatchTemplates(bot_matchtemplate_t *matches)
 {
 	FILE *fp;
 	bot_matchtemplate_t *mt;
@@ -1160,6 +1184,7 @@ void BotDumpMatchTemplates(bot_matchtemplate_t *matches)
 		fprintf(fp, " = (%d, %d);}\n", mt->type, mt->subtype);
 	} //end for
 } //end of the function BotDumpMatchTemplates
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -1514,8 +1539,12 @@ int BotFindMatch(char *str, bot_match_t *match, unsigned long int context)
 	} //end for
 	return qfalse;
 } //end of the function BotFindMatch
-
-
+//===========================================================================
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//===========================================================================
 void BotMatchVariable(bot_match_t *match, int variable, char *buf, int size)
 {
 	if (variable < 0 || variable >= MAX_MATCHVARIABLES)
@@ -1535,10 +1564,14 @@ void BotMatchVariable(bot_match_t *match, int variable, char *buf, int size)
 	else
 	{
 		buf[0] = '\0';
-	}
-}
-
-
+	} //end else
+} //end of the function BotMatchVariable
+//===========================================================================
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//===========================================================================
 static bot_stringlist_t *BotFindStringInList(bot_stringlist_t *list, const char *string)
 {
 	bot_stringlist_t *s;
@@ -1550,9 +1583,7 @@ static bot_stringlist_t *BotFindStringInList(bot_stringlist_t *list, const char 
 	}
 
 	return NULL;
-}
-
-
+} //end of the function BotFindStringInList
 //===========================================================================
 //
 // Parameter:				-
@@ -1676,13 +1707,14 @@ static void BotCheckReplyChatIntegrety(bot_replychat_t *replychat)
 		FreeMemory(s);
 	} //end for
 } //end of the function BotCheckReplyChatIntegrety
+#if 0
 //===========================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotDumpReplyChat(bot_replychat_t *replychat)
+static void BotDumpReplyChat(bot_replychat_t *replychat)
 {
 	FILE *fp;
 	bot_replychat_t *rp;
@@ -1731,6 +1763,7 @@ void BotDumpReplyChat(bot_replychat_t *replychat)
 		fprintf(fp, "}\n");
 	} //end for
 } //end of the function BotDumpReplyChat
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -2028,13 +2061,14 @@ static bot_replychat_t *BotLoadReplyChat( const char *filename )
 	//
 	return replychatlist;
 } //end of the function BotLoadReplyChat
+#if 0
 //===========================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotDumpInitialChat(bot_chat_t *chat)
+static void BotDumpInitialChat(bot_chat_t *chat)
 {
 	bot_chattype_t *t;
 	bot_chatmessage_t *m;
@@ -2053,6 +2087,7 @@ void BotDumpInitialChat(bot_chat_t *chat)
 	} //end for
 	Log_Write("}");
 } //end of the function BotDumpInitialChat
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -2301,8 +2336,12 @@ int BotLoadChatFile(int chatstate, char *chatfile, char *chatname)
 
 	return BLERR_NOERROR;
 } //end of the function BotLoadChatFile
-
-
+//===========================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//===========================================================================
 static int BotExpandChatMessage(char *outmessage, int size, char *message, unsigned long mcontext,
 							 bot_match_t *match, unsigned long vcontext, int reply)
 {
@@ -2425,9 +2464,13 @@ static int BotExpandChatMessage(char *outmessage, int size, char *message, unsig
 
 	//return true if a random was expanded
 	return expansion;
-}
-
-
+} //end of the function BotExpandChatMessage
+//===========================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//===========================================================================
 static void BotConstructChatMessage(bot_chatstate_t *chatstate, const char *message, unsigned long mcontext,
 							 bot_match_t *match, unsigned long vcontext, int reply)
 {
@@ -2449,10 +2492,8 @@ static void BotConstructChatMessage(bot_chatstate_t *chatstate, const char *mess
 	{
 		botimport.Print( PRT_WARNING, "too many expansions in chat message\n" );
 		botimport.Print( PRT_WARNING, "%s\n", chatstate->chatmessage );
-	}
-}
-
-
+	} //end if
+} //end of the function BotConstructChatMessage
 //===========================================================================
 // randomly chooses one of the chat message of the given type
 //
@@ -2644,15 +2685,14 @@ void BotInitialChat(int chatstate, char *type, int mcontext, const char *var0, c
 
 	BotConstructChatMessage( cs, message, mcontext, &match, 0, qfalse );
 }
-
-
+#if 0
 //===========================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotPrintReplyChatKeys(bot_replychat_t *replychat)
+static void BotPrintReplyChatKeys(bot_replychat_t *replychat)
 {
 	bot_replychatkey_t *key;
 	bot_matchpiece_t *mp;
@@ -2687,6 +2727,7 @@ void BotPrintReplyChatKeys(bot_replychat_t *replychat)
 	} //end for
 	botimport.Print(PRT_MESSAGE, "{\n");
 } //end of the function BotPrintReplyChatKeys
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -2868,9 +2909,7 @@ int BotReplyChat(int chatstate, char *message, int mcontext, int vcontext, const
 		return qtrue;
 	}
 	return qfalse;
-}
-
-
+} //end of the function BotReplyChat
 //===========================================================================
 //
 // Parameter:				-

--- a/code/botlib/be_ai_goal.c
+++ b/code/botlib/be_ai_goal.c
@@ -965,13 +965,14 @@ int BotGetNextCampSpotGoal(int num, bot_goal_t *goal)
 	} //end for
 	return 0;
 } //end of the function BotGetNextCampSpotGoal
+#if 0
 //===========================================================================
 //
 // Parameter:			-
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void BotFindEntityForLevelItem(levelitem_t *li)
+static void BotFindEntityForLevelItem(levelitem_t *li)
 {
 	int ent, modelindex;
 	itemconfig_t *ic;
@@ -1005,6 +1006,7 @@ void BotFindEntityForLevelItem(levelitem_t *li)
 		} //end if
 	} //end for
 } //end of the function BotFindEntityForLevelItem
+#endif
 //===========================================================================
 //
 // Parameter:			-

--- a/code/botlib/be_ai_move.c
+++ b/code/botlib/be_ai_move.c
@@ -1241,13 +1241,14 @@ int BotMoveInDirection(int movestate, vec3_t dir, float speed, int type)
 		return BotWalkInDirection(ms, dir, speed, type);
 	} //end else
 } //end of the function BotMoveInDirection
+#if 0
 //===========================================================================
 //
 // Parameter:			-
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int Intersection(vec2_t p1, vec2_t p2, vec2_t p3, vec2_t p4, vec2_t out)
+static int Intersection(vec2_t p1, vec2_t p2, vec2_t p3, vec2_t p4, vec2_t out)
 {
    float x1, dx1, dy1, x2, dx2, dy2, d;
 
@@ -1270,13 +1271,14 @@ int Intersection(vec2_t p1, vec2_t p2, vec2_t p3, vec2_t p4, vec2_t out)
       return qfalse;
    } //end else
 } //end of the function Intersection
+#endif
 //===========================================================================
 //
 // Parameter:			-
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void BotCheckBlocked(bot_movestate_t *ms, vec3_t dir, int checkbottom, bot_moveresult_t *result)
+static void BotCheckBlocked(bot_movestate_t *ms, vec3_t dir, int checkbottom, bot_moveresult_t *result)
 {
 	vec3_t mins, maxs, end, up = {0, 0, 1};
 	bsp_trace_t trace;
@@ -1372,13 +1374,14 @@ static bot_moveresult_t BotTravel_Walk(bot_movestate_t *ms, aas_reachability_t *
 	//
 	return result;
 } //end of the function BotTravel_Walk
+#if 0
 //===========================================================================
 //
 // Parameter:			-
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotFinishTravel_Walk(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotFinishTravel_Walk(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir;
 	float dist, speed;
@@ -1408,6 +1411,7 @@ bot_moveresult_t BotFinishTravel_Walk(bot_movestate_t *ms, aas_reachability_t *r
 	//
 	return result;
 } //end of the function BotFinishTravel_Walk
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -1595,7 +1599,7 @@ static bot_moveresult_t BotFinishTravel_WaterJump(bot_movestate_t *ms, aas_reach
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-bot_moveresult_t BotTravel_WalkOffLedge(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_WalkOffLedge(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir, dir;
 	float dist, speed, reachhordist;
@@ -1731,7 +1735,7 @@ static bot_moveresult_t BotFinishTravel_WalkOffLedge(bot_movestate_t *ms, aas_re
 // Changes Globals:		-
 //===========================================================================
 /*
-bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir;
 	float dist, gapdist, speed, horspeed, sv_jumpvel;
@@ -1779,7 +1783,7 @@ bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 	return result;
 } //end of the function BotTravel_Jump*/
 /*
-bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
+static bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 {
 	vec3_t hordir, dir1, dir2, mins, maxs, start, end;
 	int gapdist;

--- a/code/botlib/be_interface.c
+++ b/code/botlib/be_interface.c
@@ -215,7 +215,7 @@ static int Export_BotLibVarSet( const char *var_name, const char *value )
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int Export_BotLibVarGet( const char *var_name, char *value, int size )
+static int Export_BotLibVarGet( const char *var_name, char *value, int size )
 {
 	const char *varvalue;
 
@@ -283,7 +283,9 @@ static int Export_BotLibUpdateEntity(int ent, bot_entitystate_t *state)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
+#if 0
 void AAS_TestMovementPrediction(int entnum, vec3_t origin, vec3_t dir);
+#endif
 void ElevatorBottomCenter(aas_reachability_t *reach, vec3_t bottomcenter);
 int BotGetReachabilityToGoal(vec3_t origin, int areanum,
 									  int lastgoalareanum, int lastareanum,

--- a/code/botlib/botlib.h
+++ b/code/botlib/botlib.h
@@ -210,11 +210,11 @@ typedef struct botlib_import_s
 typedef struct aas_export_s
 {
 	//-----------------------------------
-	// be_aas_entity.h
+	// be_aas_entity.c
 	//-----------------------------------
 	void		(*AAS_EntityInfo)(int entnum, struct aas_entityinfo_s *info);
 	//-----------------------------------
-	// be_aas_main.h
+	// be_aas_main.c
 	//-----------------------------------
 	int			(*AAS_Initialized)(void);
 	void		(*AAS_PresenceTypeBoundingBox)(int presencetype, vec3_t mins, vec3_t maxs);

--- a/code/botlib/l_crc.c
+++ b/code/botlib/l_crc.c
@@ -94,6 +94,7 @@ static void CRC_Init(unsigned short *crcvalue)
 {
 	*crcvalue = CRC_INIT_VALUE;
 } //end of the function CRC_Init
+#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -104,6 +105,7 @@ void CRC_ProcessByte(unsigned short *crcvalue, byte data)
 {
 	*crcvalue = (*crcvalue << 8) ^ crctable[(*crcvalue >> 8) ^ data];
 } //end of the function CRC_ProcessByte
+#endif
 //===========================================================================
 //
 // Parameter:				-
@@ -135,6 +137,7 @@ unsigned short CRC_ProcessString(unsigned char *data, int length)
 	} //end for
 	return CRC_Value(crcvalue);
 } //end of the function CRC_ProcessString
+#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -150,3 +153,4 @@ void CRC_ContinueProcessString(unsigned short *crc, char *data, int length)
 		*crc = (*crc << 8) ^ crctable[(*crc >> 8) ^ data[i]];
 	} //end for
 } //end of the function CRC_ProcessString
+#endif

--- a/code/botlib/l_crc.h
+++ b/code/botlib/l_crc.h
@@ -21,7 +21,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 typedef unsigned short crc_t;
-
-void CRC_ProcessByte(unsigned short *crcvalue, byte data);
 unsigned short CRC_ProcessString(unsigned char *data, int length);
+#if 0
+void CRC_ProcessByte(unsigned short *crcvalue, byte data);
 void CRC_ContinueProcessString(unsigned short *crc, char *data, int length);
+#endif

--- a/code/botlib/l_libvar.c
+++ b/code/botlib/l_libvar.c
@@ -259,6 +259,7 @@ void LibVarSet( const char *var_name, const char *value )
 	//variable is modified
 	v->modified = qtrue;
 } //end of the function LibVarSet
+#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -295,3 +296,4 @@ void LibVarSetNotModified( const char *var_name )
 		v->modified = qfalse;
 	} //end if
 } //end of the function LibVarSetNotModified
+#endif

--- a/code/botlib/l_libvar.h
+++ b/code/botlib/l_libvar.h
@@ -56,8 +56,9 @@ float LibVarValue( const char *var_name, const char *value );
 const char *LibVarString( const char *var_name, const char *value );
 //sets the library variable
 void LibVarSet( const char *var_name, const char *value );
+#if 0
 //returns true if the library variable has been modified
 qboolean LibVarChanged( const char *var_name );
 //sets the library variable to unmodified
 void LibVarSetNotModified( const char *var_name );
-
+#endif

--- a/code/botlib/l_log.c
+++ b/code/botlib/l_log.c
@@ -86,7 +86,7 @@ void Log_Open( const char *filename )
 
 	Q_strncpyz( logfile.filename, filename, sizeof( logfile.filename ) );
 	botimport.Print( PRT_MESSAGE, "Opened log %s\n", logfile.filename );
-} //end of the function Log_Create
+} //end of the function Log_Open
 //===========================================================================
 //
 // Parameter:				-
@@ -131,6 +131,7 @@ void QDECL Log_Write(char *fmt, ...)
 	//fprintf(logfile.fp, "\r\n");
 	fflush(logfile.fp);
 } //end of the function Log_Write
+#if 0
 //===========================================================================
 //
 // Parameter:				-
@@ -155,7 +156,8 @@ void QDECL Log_WriteTimeStamped(char *fmt, ...)
 	fprintf(logfile.fp, "\r\n");
 	logfile.numwrites++;
 	fflush(logfile.fp);
-} //end of the function Log_Write
+} //end of the function Log_WriteTimeStamped
+#endif
 //===========================================================================
 //
 // Parameter:				-

--- a/code/botlib/l_log.h
+++ b/code/botlib/l_log.h
@@ -35,8 +35,10 @@ void Log_Open( const char *filename );
 void Log_Shutdown(void);
 //write to the current opened log file
 void QDECL Log_Write(char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+#if 0
 //write to the current opened log file with a time stamp
 void QDECL Log_WriteTimeStamped(char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+#endif
 //returns a pointer to the log file
 FILE *Log_FilePointer(void);
 //flush log file

--- a/code/botlib/l_precomp.c
+++ b/code/botlib/l_precomp.c
@@ -451,8 +451,6 @@ static int PC_ReadDefineParms(source_t *source, define_t *define, token_t **parm
 	} //end for
 	return qtrue;
 } //end of the function PC_ReadDefineParms
-
-
 //============================================================================
 //
 // Parameter:				-
@@ -480,9 +478,7 @@ static int PC_StringizeTokens( const token_t *tokens, token_t *token )
 	strcpy( token->string + total, "\"" );
 
 	return qtrue;
-}
-
-
+} //end of the function PC_StringizeTokens
 //============================================================================
 //
 // Parameter:				-
@@ -514,9 +510,7 @@ static int PC_MergeTokens(token_t *t1, token_t *t2)
 	}
 	//FIXME: merging of two number of the same sub type
 	return qfalse;
-}
-
-
+} //end of the function PC_MergeTokens
 //============================================================================
 //
 // Parameter:				-
@@ -535,13 +529,14 @@ void PC_PrintDefine(define_t *define)
 //	struct define_s *next;			//next defined macro in a list
 } //end of the function PC_PrintDefine*/
 #if DEFINEHASHING
+#if 0
 //============================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_PrintDefineHashTable(define_t **definehash)
+static void PC_PrintDefineHashTable(define_t **definehash)
 {
 	int i;
 	define_t *d;
@@ -556,6 +551,7 @@ void PC_PrintDefineHashTable(define_t **definehash)
 		Log_Write("\n");
 	} //end for
 } //end of the function PC_PrintDefineHashTable
+#endif
 //============================================================================
 //
 // Parameter:				-
@@ -610,7 +606,7 @@ static define_t *PC_FindHashedDefine(define_t **definehash, char *name)
 	} //end for
 	return NULL;
 } //end of the function PC_FindHashedDefine
-#endif //DEFINEHASHING
+#else //DEFINEHASHING
 //============================================================================
 //
 // Parameter:				-
@@ -627,6 +623,7 @@ static define_t *PC_FindDefine(define_t *defines, char *name)
 	} //end for
 	return NULL;
 } //end of the function PC_FindDefine
+#endif //DEFINEHASHING
 //============================================================================
 //
 // Parameter:				-
@@ -673,13 +670,14 @@ static void PC_FreeDefine(define_t *define)
 	FreeMemory(define->name);
 	FreeMemory(define);
 } //end of the function PC_FreeDefine
+#if 0
 //============================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-void PC_AddBuiltinDefines(source_t *source)
+static void PC_AddBuiltinDefines(source_t *source)
 {
 	int i;
 	define_t *define;
@@ -713,6 +711,7 @@ void PC_AddBuiltinDefines(source_t *source)
 #endif //DEFINEHASHING
 	} //end for
 } //end of the function PC_AddBuiltinDefines
+#endif
 //============================================================================
 //
 // Parameter:				-
@@ -1378,13 +1377,14 @@ static define_t *PC_DefineFromString(const char *string)
 	//
 	return NULL;
 } //end of the function PC_DefineFromString
+#if 0
 //============================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_AddDefine(source_t *source, char *string)
+static int PC_AddDefine(source_t *source, char *string)
 {
 	define_t *define;
 
@@ -1398,6 +1398,7 @@ int PC_AddDefine(source_t *source, char *string)
 #endif //DEFINEHASHING
 	return qtrue;
 } //end of the function PC_AddDefine
+#endif
 //============================================================================
 // add a globals define that will be added to all opened sources
 //
@@ -1415,6 +1416,7 @@ int PC_AddGlobalDefine(const char *string)
 	globaldefines = define;
 	return qtrue;
 } //end of the function PC_AddGlobalDefine
+#if 0
 //============================================================================
 // remove the given global define
 //
@@ -1434,6 +1436,7 @@ int PC_RemoveGlobalDefine(char *name)
 	} //end if
 	return qfalse;
 } //end of the function PC_RemoveGlobalDefine
+#endif
 //============================================================================
 // remove all globals defines
 //
@@ -2664,7 +2667,7 @@ static int PC_ReadDollarDirective(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int BuiltinFunction(source_t *source)
+static int BuiltinFunction(source_t *source)
 {
 	token_t token;
 
@@ -2686,7 +2689,7 @@ int BuiltinFunction(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int QuakeCMacro(source_t *source)
+static int QuakeCMacro(source_t *source)
 {
 	int i;
 	token_t token;
@@ -2905,6 +2908,7 @@ int PC_CheckTokenString(source_t *source, char *string)
 	PC_UnreadSourceToken(source, &tok);
 	return qfalse;
 } //end of the function PC_CheckTokenString
+#if 0
 //============================================================================
 //
 // Parameter:				-
@@ -2943,6 +2947,7 @@ int PC_SkipUntilString(source_t *source, char *string)
 	} //end while
 	return qfalse;
 } //end of the function PC_SkipUntilString
+#endif
 //============================================================================
 //
 // Parameter:				-
@@ -2963,6 +2968,7 @@ void PC_UnreadToken(source_t *source, token_t *token)
 {
 	PC_UnreadSourceToken(source, token);
 } //end of the function PC_UnreadToken
+#if 0
 //============================================================================
 //
 // Parameter:				-
@@ -2993,6 +2999,7 @@ void PC_SetPunctuations(source_t *source, punctuation_t *p)
 {
 	source->punctuations = p;
 } //end of the function PC_SetPunctuations
+#endif
 //============================================================================
 //
 // Parameter:			-
@@ -3027,6 +3034,7 @@ source_t *LoadSourceFile(const char *filename)
 	PC_AddGlobalDefinesToSource(source);
 	return source;
 } //end of the function LoadSourceFile
+#if 0
 //============================================================================
 //
 // Parameter:				-
@@ -3060,6 +3068,7 @@ source_t *LoadSourceMemory(char *ptr, int length, char *name)
 	PC_AddGlobalDefinesToSource(source);
 	return source;
 } //end of the function LoadSourceMemory
+#endif
 //============================================================================
 //
 // Parameter:				-
@@ -3215,14 +3224,22 @@ int PC_SourceFileAndLine(int handle, char *filename, int *line)
 		*line = 0;
 	return qtrue;
 } //end of the function PC_SourceFileAndLine
-
-
+//============================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//============================================================================
 void PC_SetBaseFolder( const char *path )
 {
 	PS_SetBaseFolder( path );
-}
-
-
+} //end of the function PC_SetBaseFolder
+//============================================================================
+//
+// Parameter:			-
+// Returns:				-
+// Changes Globals:		-
+//============================================================================
 void PC_CheckOpenSourceHandles( void )
 {
 	int i;
@@ -3233,7 +3250,8 @@ void PC_CheckOpenSourceHandles( void )
 		{
 #ifdef BOTLIB
 			botimport.Print(PRT_ERROR, "file %s still open in precompiler\n", sourceFiles[i]->scriptstack->filename);
-#endif
-		}
-	}
-}
+#endif	//BOTLIB
+		} //end if
+	} //end for
+} //end of the function PC_CheckOpenSourceHandles
+

--- a/code/botlib/l_precomp.h
+++ b/code/botlib/l_precomp.h
@@ -117,34 +117,36 @@ int PC_ExpectTokenType(source_t *source, int type, int subtype, token_t *token);
 int PC_ExpectAnyToken(source_t *source, token_t *token);
 //returns true when the token is available
 int PC_CheckTokenString(source_t *source, char *string);
-//returns true and reads the token when a token with the given type is available
-int PC_CheckTokenType(source_t *source, int type, int subtype, token_t *token);
-//skip tokens until the given token string is read
-int PC_SkipUntilString(source_t *source, char *string);
 //unread the last token read from the script
 void PC_UnreadLastToken(source_t *source);
 //unread the given token
 void PC_UnreadToken(source_t *source, token_t *token);
-//add a define to the source
-int PC_AddDefine(source_t *source, char *string);
 //add a globals define that will be added to all opened sources
 int PC_AddGlobalDefine(const char *string);
-//remove the given global define
-int PC_RemoveGlobalDefine(char *name);
 //remove all globals defines
 void PC_RemoveAllGlobalDefines(void);
+#if 0
+//skip tokens until the given token string is read
+int PC_SkipUntilString(source_t *source, char *string);
+//returns true and reads the token when a token with the given type is available
+int PC_CheckTokenType(source_t *source, int type, int subtype, token_t *token);
+//remove the given global define
+int PC_RemoveGlobalDefine(char *name);
+//add a define to the source
+int PC_AddDefine(source_t *source, char *string);
 //add builtin defines
 void PC_AddBuiltinDefines(source_t *source);
 //set the source include path
 void PC_SetIncludePath(source_t *source, const char *path);
 //set the punction set
 void PC_SetPunctuations(source_t *source, punctuation_t *p);
+//load a source from memory
+source_t *LoadSourceMemory(char *ptr, int length, char *name);
+#endif
 //set the base folder to load files from
 void PC_SetBaseFolder(const char *path);
 //load a source file
 source_t *LoadSourceFile(const char *filename);
-//load a source from memory
-source_t *LoadSourceMemory(char *ptr, int length, char *name);
 //free the given source
 void FreeSource(source_t *source);
 //print a source error

--- a/code/botlib/l_script.c
+++ b/code/botlib/l_script.c
@@ -727,13 +727,14 @@ static int PS_ReadNumber(script_t *script, token_t *token)
 	if (!(token->subtype & TT_FLOAT)) token->subtype |= TT_INTEGER;
 	return 1;
 } //end of the function PS_ReadNumber
+#if 0
 //============================================================================
 //
 // Parameter:				-
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PS_ReadLiteral(script_t *script, token_t *token)
+static int PS_ReadLiteral(script_t *script, token_t *token)
 {
 	token->type = TT_LITERAL;
 	//first quote
@@ -774,6 +775,7 @@ int PS_ReadLiteral(script_t *script, token_t *token)
 	//
 	return 1;
 } //end of the function PS_ReadLiteral
+#endif
 //============================================================================
 //
 // Parameter:				-
@@ -915,6 +917,7 @@ int PS_ReadToken(script_t *script, token_t *token)
 	//successfully read a token
 	return 1;
 } //end of the function PS_ReadToken
+#if 0
 //============================================================================
 //
 // Parameter:				-
@@ -938,6 +941,7 @@ int PS_ExpectTokenString(script_t *script, const char *string)
 	} //end if
 	return 1;
 } //end of the function PS_ExpectToken
+#endif
 //============================================================================
 //
 // Parameter:				-
@@ -1016,6 +1020,7 @@ int PS_ExpectAnyToken(script_t *script, token_t *token)
 		return 1;
 	} //end else
 } //end of the function PS_ExpectAnyToken
+#if 0
 //============================================================================
 //
 // Parameter:				-
@@ -1071,6 +1076,7 @@ int PS_SkipUntilString(script_t *script, const char *string)
 	} //end while
 	return 0;
 } //end of the function PS_SkipUntilString
+#endif
 //============================================================================
 //
 // Parameter:				-
@@ -1081,6 +1087,7 @@ void PS_UnreadLastToken(script_t *script)
 {
 	script->tokenavailable = 1;
 } //end of the function UnreadLastToken
+#if 0
 //============================================================================
 //
 // Parameter:				-
@@ -1110,6 +1117,7 @@ char PS_NextWhiteSpaceChar(script_t *script)
 		return 0;
 	} //end else
 } //end of the function PS_NextWhiteSpaceChar
+#endif
 //============================================================================
 //
 // Parameter:				-
@@ -1144,6 +1152,7 @@ void StripSingleQuotes(char *string)
 		string[strlen(string)-1] = '\0';
 	} //end if
 } //end of the function StripSingleQuotes
+#if 0
 //============================================================================
 //
 // Parameter:				-
@@ -1206,6 +1215,7 @@ signed long int ReadSignedInt(script_t *script)
 	
 	return sign * token.intvalue;
 } //end of the function ReadSignedInt
+#endif
 //============================================================================
 //
 // Parameter:				-
@@ -1216,6 +1226,7 @@ void SetScriptFlags(script_t *script, int flags)
 {
 	script->flags = flags;
 } //end of the function SetScriptFlags
+#if 0
 //============================================================================
 //
 // Parameter:				-
@@ -1250,6 +1261,7 @@ void ResetScript(script_t *script)
 	//clear the saved token
 	Com_Memset(&script->token, 0, sizeof(token_t));
 } //end of the function ResetScript
+#endif
 //============================================================================
 // returns true if at the end of the script
 //
@@ -1261,6 +1273,7 @@ int EndOfScript(script_t *script)
 {
 	return script->script_p >= script->end_p;
 } //end of the function EndOfScript
+#if 0
 //============================================================================
 //
 // Parameter:				-
@@ -1297,6 +1310,7 @@ int ScriptSkipTo(script_t *script, char *value)
 		script->script_p++;
 	} while(1);
 } //end of the function ScriptSkipTo
+#endif
 #ifndef BOTLIB
 //============================================================================
 //
@@ -1434,10 +1448,15 @@ void FreeScript(script_t *script)
 #endif //PUNCTABLE
 	FreeMemory(script);
 } //end of the function FreeScript
-
-
-//set the base folder to load files from
+//============================================================================
+// set the base folder to load files from
+//
+// Parameter:				-
+// Returns:					-
+// Changes Globals:		-
+//============================================================================
 void PS_SetBaseFolder( const char *path )
 {
 	Q_strncpyz( basefolder, path, sizeof( basefolder ) );
-}
+} //end of the function PS_SetBaseFolder
+

--- a/code/botlib/l_script.h
+++ b/code/botlib/l_script.h
@@ -193,38 +193,40 @@ typedef struct script_s
 
 //read a token from the script
 int PS_ReadToken(script_t *script, token_t *token);
-//expect a certain token
-int PS_ExpectTokenString(script_t *script, const char *string);
 //expect a certain token type
 int PS_ExpectTokenType(script_t *script, int type, int subtype, token_t *token);
 //expect a token
 int PS_ExpectAnyToken(script_t *script, token_t *token);
+#if 0
+//expect a certain token
+int PS_ExpectTokenString(script_t *script, const char *string);
 //returns true when the token is available
 int PS_CheckTokenString(script_t *script, const char *string);
 //returns true and reads the token when a token with the given type is available
 int PS_CheckTokenType(script_t *script, int type, int subtype, token_t *token);
 //skip tokens until the given token string is read
 int PS_SkipUntilString(script_t *script, const char *string);
-//unread the last token read from the script
-void PS_UnreadLastToken(script_t *script);
 //unread the given token
 void PS_UnreadToken(script_t *script, token_t *token);
 //returns the next character of the read white space, returns NULL if none
 char PS_NextWhiteSpaceChar(script_t *script);
-//remove any leading and trailing double quotes from the token
-void StripDoubleQuotes(char *string);
-//remove any leading and trailing single quotes from the token
-void StripSingleQuotes(char *string);
 //read a possible signed integer
 signed long int ReadSignedInt(script_t *script);
 //read a possible signed floating point number
 float ReadSignedFloat(script_t *script);
-//set script flags
-void SetScriptFlags(script_t *script, int flags);
 //get script flags
 int GetScriptFlags(script_t *script);
 //reset a script
 void ResetScript(script_t *script);
+#endif
+//unread the last token read from the script
+void PS_UnreadLastToken(script_t *script);
+//remove any leading and trailing double quotes from the token
+void StripDoubleQuotes(char *string);
+//remove any leading and trailing single quotes from the token
+void StripSingleQuotes(char *string);
+//set script flags
+void SetScriptFlags(script_t *script, int flags);
 //returns true if at the end of the script
 int EndOfScript(script_t *script);
 //returns a pointer to the punctuation with the given number

--- a/code/botlib/l_struct.c
+++ b/code/botlib/l_struct.c
@@ -57,7 +57,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-fielddef_t *FindField(fielddef_t *defs, char *name)
+static fielddef_t *FindField(fielddef_t *defs, char *name)
 {
 	int i;
 
@@ -73,7 +73,7 @@ fielddef_t *FindField(fielddef_t *defs, char *name)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-qboolean ReadNumber(source_t *source, fielddef_t *fd, void *p)
+static qboolean ReadNumber(source_t *source, fielddef_t *fd, void *p)
 {
 	token_t token;
 	int negative = qfalse;
@@ -188,7 +188,7 @@ qboolean ReadNumber(source_t *source, fielddef_t *fd, void *p)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-qboolean ReadChar(source_t *source, fielddef_t *fd, void *p)
+static qboolean ReadChar(source_t *source, fielddef_t *fd, void *p)
 {
 	token_t token;
 
@@ -213,7 +213,7 @@ qboolean ReadChar(source_t *source, fielddef_t *fd, void *p)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int ReadString(source_t *source, fielddef_t *fd, void *p)
+static int ReadString(source_t *source, fielddef_t *fd, void *p)
 {
 	token_t token;
 
@@ -366,7 +366,7 @@ int WriteFloat(FILE *fp, float value)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int WriteStructWithIndent(FILE *fp, structdef_t *def, char *structure, int indent)
+static int WriteStructWithIndent(FILE *fp, structdef_t *def, char *structure, int indent)
 {
 	int i, num;
 	void *p;


### PR DESCRIPTION
# Clean up unused (static) botlib functions.

Please note that there is a [second, alternate version](https://github.com/ec-/Quake3e/pull/171) of this pull request.
Only the 'botlib' module is affected (atm).

Previously we declared a few functions that are static as such. Many other unused functions are also meant of being used as static functions (they only exist in one single file in the correct order), but they were also not declared as static, like the others.
Unfortunately if we declare them as static like the other ones, compliers will throw out a warning these functions are definded but not used.

This pull requests deals with such functions. We declare them as static and tell the compiler to not use them, because they aren't needed.
There are a few ways to tell the compiler to ignore code. By some special characters like // or /*, or by #if 0 them, or by simply removing the specific lines of code.
The pros of somehow mark code as to be ignored is that it still exists, and someone can eventually have a look at it, for whatever reason.
Unfortunately with lot of #if 0 we will very likely end up in a real #ifdef hell. For a few lines it might be better to #if 0 them, on the other hand for such big removal as done with this pull request a real deletion of code might be the better choice. Hence the two versions of the same pull request.

Version 1: the pull request will DISABLE the code by using #if 0.
Version 2: the pull request will DELETE the code, only a few functions will be disabled by using #if 0.

Why is version 2 not deleting all disabled code? Well, this needs some further explanation:
The idtech3 botlib code is a very 'aged' code. You can find some pieces that refers to QUAKE-C (a unique programming language), some pieces of code refers to the Quake 2 bots, etc. Anyways, even with that age the code was reused, revised and modified for Return to Castle Wolfenstein and even for Wolfenstein - Enemy Territory as well. Some parts of the code was already existing in the botlib but was only used later, after Quake3  (for example working ladders).
This means every time someone is removing code (like we do here) he potentially destroys the support for using the botlib (engine) for later games.
This is the reason why some functions will NOT be completely deleted, because other games will maybe need this functions, hence they are just disabled. Only those functions will be deleted that are either never worked, are just crap, or were never used by other engines (at least I'm aware of). Also unused functions were kept that are used for debugging.
Now if you read through the code base you will find even more functions that could be static but I didn't make them static, nor did I delete them although they aren't used as well.
The reason is simple, the code base also contains code that is necessary for external code. In specific this means if someone adds the code for the BSPC tool (a tool to create AAS files from BSP files), and he wants to compile this code than this 'unused' code from botlib is used. This is another reason why some 'unused' functions aren't removed or disabled.
The whole BSPC situation is a bit tricky because there are a few existing 'forks' of the BSPC tool. RtCW is using a different version than Q3 (2.1h), OpenArena tried using a special one for OA (?), but even classic or non-true-idtech3 games like WARSOW are using its own BSPC tool. Not to speak of Spearmint, which also has its own BSPC version.
Spearmint is the most updated and fixed one as far as I know, and there the BSPC tool is already attached into the code base (thanks to zturtleman). This was the reason I was able to actually understand what functions are used by the BSPC tool although the code resides in the idtech3 engine code.
I compiled different BSPC tools and engines and I hope I get the best results in keeping everything that is needed even for different engines/forks.

Well, actually this isn't so important I think. Though, the BSPC situation leads to another point, not concerning the botlib, read on!

As you can see I left the cm_ files in qcommon completely untouched, for two reasons:
1. The BSPC tool (at least some forks) also uses code from there (like I described it above for the botlib files).
2. The cm_ files also are a bit different as far as used/unused functions per engine are concerned. For example most functions 
   could be static, because they are static by its nature, and because they are used as such. As soon as you declare them as static the compiler tells us that they aren't used. This is either because the BSPC tool needs these function but not the Q3e engine or they are really unused, but even if we know what functions are really NOT used by the BSPC tool, it is very likely that other engines use these functions. Spearmint for example uses some functions that Q3e isn't using, iirc, and I think Wolfenstein - Enemy Territory and therefore ETe uses also some functions from cm_ files that Q3e isn't using at all.
   
My knowledge of the collision part and the cm_ files are too low to decide which functions should be static if  any. I leave it up to you to decide.
## ***What is changing:***
  + Unused 'static' functions will be disabled/removed from code base.
## ***Notes:***
  + Onyl code is affected we declared as 'static' or turned into being unused because the static function was unused as well. There is lot of crap inside the botlib code that will NOT be removed with this pull request.
  + A clean-up of most of the crap will follow, but I tend to use smaller steps.
  + At some places I added back in the ugly botlib comment style from vQ3 1.32 (just a few lines, I hope this is okay). This is due my workflow (SVN + WinMerge). Yes, yes I know I'm really old. Anyways, this way I was able to do these changes to other engines and can better check the stuff mentioned in the description to this ticket.
  + Something to consider is that other engines evolves as well, I can only refer to the state they are in concerning the last ten years (WoP and Spearmint also turned many functions into static functions).
  + Again, remember that there are two versions of this pull request. I know pull requests aren't really used that way, but I don't know of any other way to let you choose the one that better suits your needs.
  + If you choose one PR we need to close both of course, because they aren't interchangeable.