### PR TITLE
renderer2 fixes for dark models left over from changes some time ago

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,10 @@ ifeq ($(COMPILE_PLATFORM),darwin)
     CLIENT_LDFLAGS = -F/Library/Frameworks -framework SDL2
   endif
 
+  ifeq ($(USE_SYSTEM_JPEG),1)
+    CLIENT_LDFLAGS += -ljpeg
+  endif
+
   DEBUG_CFLAGS = $(BASE_CFLAGS) -DDEBUG -D_DEBUG -g -O0
   RELEASE_CFLAGS = $(BASE_CFLAGS) -DNDEBUG $(OPTIMIZE)
 

--- a/code/renderer2/qgl.h
+++ b/code/renderer2/qgl.h
@@ -40,6 +40,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #elif defined( __linux__ ) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined( __sun )
 #include <GL/gl.h>
 #include <GL/glx.h>
+#elif defined(__APPLE__)
+#define GL_NUM_EXTENSIONS                 0x821D
+#include <OpenGL/gl.h>
+#include <OpenGL/glext.h>
 #endif
 
 #ifndef APIENTRY

--- a/code/renderer2/tr_bsp.c
+++ b/code/renderer2/tr_bsp.c
@@ -673,15 +673,15 @@ static void LoadDrawVertToSrfVert(srfVert_t *s, const drawVert_t *d, int realLig
 		//hack: convert LDR vertex colors to HDR
 		if (r_hdr->integer)
 		{
-			v[0] = MAX(d->color.rgba[0] / 255.0f, 0.499f);
-			v[1] = MAX(d->color.rgba[1] / 255.0f, 0.499f);
-			v[2] = MAX(d->color.rgba[2] / 255.0f, 0.499f);
+			v[0] = MAX(d->color.rgba[0], 0.499f);
+			v[1] = MAX(d->color.rgba[1], 0.499f);
+			v[2] = MAX(d->color.rgba[2], 0.499f);
 		}
 		else
 		{
-			v[0] = d->color.rgba[0] / 255.0f;
-			v[1] = d->color.rgba[1] / 255.0f;
-			v[2] = d->color.rgba[2] / 255.0f;
+			v[0] = d->color.rgba[0];
+			v[1] = d->color.rgba[1];
+			v[2] = d->color.rgba[2];
 		}
 
 	}

--- a/code/renderer2/tr_dsa.c
+++ b/code/renderer2/tr_dsa.c
@@ -143,7 +143,7 @@ GLvoid APIENTRY GLDSA_GenerateTextureMipmapEXT(GLuint texture, GLenum target)
 
 void GL_BindNullProgram(void)
 {
-	qglUseProgram(0);
+	qglUseProgram((unsigned)0);
 	glDsaState.program = 0;
 }
 

--- a/code/renderer2/tr_image.c
+++ b/code/renderer2/tr_image.c
@@ -204,7 +204,7 @@ void R_ImageList_f( void ) {
 				// same as DXT1?
 				estSize /= 2;
 				break;
-			case GL_RGBA16F:
+			case GL_RGBA16F_ARB:
 				format = "RGBA16F";
 				// 8 bytes per pixel
 				estSize *= 8;

--- a/code/renderer2/tr_shader.c
+++ b/code/renderer2/tr_shader.c
@@ -1350,6 +1350,10 @@ static qboolean ParseStage( shaderStage_t *stage, const char **text )
 
 			continue;
 		}
+		else if ( !Q_stricmp( token, "depthFragment" ) )
+		{
+			continue;
+		}
 		else
 		{
 			ri.Printf( PRINT_WARNING, "WARNING: unknown parameter '%s' in shader '%s'\n", token, shader.name );

--- a/code/renderer2/tr_surface.c
+++ b/code/renderer2/tr_surface.c
@@ -293,10 +293,10 @@ static void RB_SurfacePolychain( const srfPoly_t *p ) {
 		VectorCopy( p->verts[i].xyz, tess.xyz[numv] );
 		tess.texCoords[numv][0] = p->verts[i].st[0];
 		tess.texCoords[numv][1] = p->verts[i].st[1];
-		tess.color[numv][0] = p->verts[i].modulate.rgba[0] * 257;
-		tess.color[numv][1] = p->verts[i].modulate.rgba[1] * 257;
-		tess.color[numv][2] = p->verts[i].modulate.rgba[2] * 257;
-		tess.color[numv][3] = p->verts[i].modulate.rgba[3] * 257;
+		tess.color[numv][0] = (int)p->verts[i].modulate.rgba[0] * 257;
+		tess.color[numv][1] = (int)p->verts[i].modulate.rgba[1] * 257;
+		tess.color[numv][2] = (int)p->verts[i].modulate.rgba[2] * 257;
+		tess.color[numv][3] = (int)p->verts[i].modulate.rgba[3] * 257;
 
 		numv++;
 	}


### PR DESCRIPTION
Every time I reset I have to re-apply these, maybe upstream would like them. I'm still using renderer2.

Also added MacOS -ljpeg to save time compiling. It is not default behavior like on Linux.

EDIT: This is the old commit that created the error by leaving out these lines.

https://github.com/ec-/Quake3e/commit/ae4427ff7918dac1a75ae03a10290db524304c15
