### PR TITLE
sdl_glimp: save window position before quit

### DIFF
--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -63,6 +63,9 @@ GLimp_Shutdown
 */
 void GLimp_Shutdown( qboolean unloadDLL )
 {
+	Cvar_SetIntegerValue( "vid_xpos", glw_state.window_width );
+	Cvar_SetIntegerValue( "vid_ypos", glw_state.window_height );
+
 	IN_Shutdown();
 
 	SDL_DestroyWindow( SDL_window );
@@ -778,6 +781,9 @@ VKimp_Shutdown
 */
 void VKimp_Shutdown( qboolean unloadDLL )
 {
+	Cvar_SetIntegerValue( "vid_xpos", glw_state.window_width );
+	Cvar_SetIntegerValue( "vid_ypos", glw_state.window_height );
+
 	IN_Shutdown();
 
 	SDL_DestroyWindow( SDL_window );


### PR DESCRIPTION
`quake3e` always choose [nearest display based on stored `vid_xpos` and `vid_ypos`](https://github.com/ec-/Quake3e/blob/master/code/sdl/sdl_glimp.c#L225). But here's the catch: these values are never modified if window position is changed (e.g. `quake3e` moved to another display). At least, for `SDL_VIDEODRIVER=wayland`.

This commit introduces storing state of window position upon shutdown of client.

This is my first contribution (aka "quickly hacked solution") to any public **C** code, so I apologize in advance if I didn't understand something / didn't put these functions in appropriate place. Thanks!