### PR TITLE
Fix deprecated warnings on modern CURL versions

### DIFF
--- a/code/client/cl_curl.c
+++ b/code/client/cl_curl.c
@@ -26,6 +26,8 @@ cvar_t *cl_cURLLib;
 
 #define ALLOWED_PROTOCOLS ( CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP | CURLPROTO_FTPS )
 
+#define ALLOWED_PROTOCOLS_STR "http,https,ftp,ftps"
+
 #ifdef USE_CURL_DLOPEN
 
 char* (*qcurl_version)(void);
@@ -219,8 +221,13 @@ void CL_cURL_Cleanup(void)
 	}
 }
 
+#if CURL_AT_LEAST_VERSION(7, 32, 0)
+static int CL_cURL_CallbackProgress( void *dummy, curl_off_t dltotal, curl_off_t dlnow,
+	curl_off_t ultotal, curl_off_t ulnow )
+#else
 static int CL_cURL_CallbackProgress( void *dummy, double dltotal, double dlnow,
 	double ultotal, double ulnow )
+#endif
 {
 	clc.downloadSize = (int)dltotal;
 	Cvar_SetIntegerValue( "cl_downloadSize", clc.downloadSize );
@@ -319,24 +326,34 @@ void CL_cURL_BeginDownload( const char *localName, const char *remoteURL )
 	}
 
 	if ( com_developer->integer )
-		qcurl_easy_setopt( clc.downloadCURL, CURLOPT_VERBOSE, 1 );
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_URL, clc.downloadURL);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_TRANSFERTEXT, 0);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_REFERER, va("ioQ3://%s",
+		qcurl_easy_setopt_warn( clc.downloadCURL, CURLOPT_VERBOSE, 1 );
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_URL, clc.downloadURL);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_TRANSFERTEXT, 0);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_REFERER, va("ioQ3://%s",
 		NET_AdrToString(&clc.serverAddress)));
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_USERAGENT, Q3_VERSION);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_WRITEFUNCTION,
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_USERAGENT, Q3_VERSION);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_WRITEFUNCTION,
 		CL_cURL_CallbackWrite);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_WRITEDATA, &clc.download);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_NOPROGRESS, 0);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_PROGRESSFUNCTION,
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_WRITEDATA, &clc.download);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_NOPROGRESS, 0);
+#if CURL_AT_LEAST_VERSION(7, 32, 0)
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_XFERINFOFUNCTION,
 		CL_cURL_CallbackProgress);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_PROGRESSDATA, NULL);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_FAILONERROR, 1);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_FOLLOWLOCATION, 1);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_MAXREDIRS, 5);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_PROTOCOLS, ALLOWED_PROTOCOLS);
-	qcurl_easy_setopt(clc.downloadCURL, CURLOPT_BUFFERSIZE, CURL_MAX_READ_SIZE);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_XFERINFODATA, NULL);
+#else
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_PROGRESSFUNCTION,
+		CL_cURL_CallbackProgress);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_PROGRESSDATA, NULL);
+#endif
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_FAILONERROR, 1);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_FOLLOWLOCATION, 1);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_MAXREDIRS, 5);
+#if CURL_AT_LEAST_VERSION(7, 85, 0)
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_PROTOCOLS_STR, ALLOWED_PROTOCOLS_STR);
+#else
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_PROTOCOLS, ALLOWED_PROTOCOLS);
+#endif
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_BUFFERSIZE, CURL_MAX_READ_SIZE);
 
 	clc.downloadCURLM = qcurl_multi_init();	
 	if( !clc.downloadCURLM ) {
@@ -700,9 +717,18 @@ static const char *sizeToString( int size )
 Com_DL_CallbackProgress
 =================
 */
+#if CURL_AT_LEAST_VERSION(7, 32, 0)
+static int Com_DL_CallbackProgress( void *data, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow )
+#else
 static int Com_DL_CallbackProgress( void *data, double dltotal, double dlnow, double ultotal, double ulnow )
+#endif
 {
-	double percentage, speed;
+	double percentage;
+#if CURL_AT_LEAST_VERSION(7, 55, 0)
+	curl_off_t speed;
+#else
+	double speed;
+#endif
 	download_t *dl = (download_t *)data;
 
 	dl->Size = (int)dltotal;
@@ -726,7 +752,12 @@ static int Com_DL_CallbackProgress( void *data, double dltotal, double dlnow, do
 		sprintf( dl->progress, " downloading %s: %s", dl->Name, sizeToString( dl->Count ) );
 	}
 
-	if ( dl->func.easy_getinfo( dl->cURL, CURLINFO_SPEED_DOWNLOAD, &speed ) == CURLE_OK ) {
+#if CURL_AT_LEAST_VERSION(7, 55, 0)
+	if ( dl->func.easy_getinfo( dl->cURL, CURLINFO_SPEED_DOWNLOAD_T, &speed ) == CURLE_OK )
+#else
+	if ( dl->func.easy_getinfo( dl->cURL, CURLINFO_SPEED_DOWNLOAD, &speed ) == CURLE_OK )
+#endif
+	{
 		Q_strcat( dl->progress, sizeof( dl->progress ), va( " %s/s", sizeToString( (int)speed ) ) );
 	}
 
@@ -958,12 +989,21 @@ qboolean Com_DL_Begin( download_t *dl, const char *localName, const char *remote
 		dl->func.easy_setopt( dl->cURL, CURLOPT_HEADERDATA, dl );
 	}
 	dl->func.easy_setopt( dl->cURL, CURLOPT_NOPROGRESS, 0 );
+#if CURL_AT_LEAST_VERSION(7, 32, 0)
+	dl->func.easy_setopt( dl->cURL, CURLOPT_XFERINFOFUNCTION, Com_DL_CallbackProgress );
+	dl->func.easy_setopt( dl->cURL, CURLOPT_XFERINFODATA, dl );
+#else
 	dl->func.easy_setopt( dl->cURL, CURLOPT_PROGRESSFUNCTION, Com_DL_CallbackProgress );
 	dl->func.easy_setopt( dl->cURL, CURLOPT_PROGRESSDATA, dl );
+#endif
 	dl->func.easy_setopt( dl->cURL, CURLOPT_FAILONERROR, 1 );
 	dl->func.easy_setopt( dl->cURL, CURLOPT_FOLLOWLOCATION, 1 );
 	dl->func.easy_setopt( dl->cURL, CURLOPT_MAXREDIRS, 5 );
+#if CURL_AT_LEAST_VERSION(7, 85, 0)
+	dl->func.easy_setopt( dl->cURL, CURLOPT_PROTOCOLS_STR, ALLOWED_PROTOCOLS_STR );
+#else
 	dl->func.easy_setopt( dl->cURL, CURLOPT_PROTOCOLS, ALLOWED_PROTOCOLS );
+#endif
 	dl->func.easy_setopt( dl->cURL, CURLOPT_BUFFERSIZE, CURL_MAX_READ_SIZE );
 
 	dl->cURLM = dl->func.multi_init();


### PR DESCRIPTION
Not positive percentage in Com_DL_CallbackProgress will suffice with int64/int64 * 100 staying as a double.

And if we need to change the speed being truncated to int32 for display sizeToString.