### PR TITLE
CMake: fix SDL2 caller and name mismatch

### DIFF
--- a/cmake_modules/FindSDL2.cmake
+++ b/cmake_modules/FindSDL2.cmake
@@ -42,13 +42,15 @@ This module defines the following 'IMPORTED' targets:
 
 ::
 
-  SDL2::Core
+  SDL2::Core (for compatibility with older versions)
+  SDL2::SDL2 (compatibility with CONFIG mode)
     The SDL2 library, if found.
-    Libraries should link to SDL2::Core
+    Libraries should link to SDL2::SDL2
 
-  SDL2::Main
+  SDL2::Main (for compatibility with older versions)
+  SDL2::SDL2main (compatibility with CONFIG mode)
     The SDL2main library, if found.
-    Applications should link to SDL2::Main instead of SDL2::Core
+    Applications should link to SDL2::SDL2main instead of SDL2::SDL2
 
 
 
@@ -310,16 +312,14 @@ endif()
 
 include(FindPackageHandleStandardArgs)
 
+set(SDL2_REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
+if(SDL2MAIN_LIBRARY)
+    list(APPEND SDL2_REQUIRED_VARS SDL2MAIN_LIBRARY SDL2_INCLUDE_DIR)
+endif()
+
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2
         REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR
         VERSION_VAR SDL2_VERSION_STRING)
-
-if(SDL2MAIN_LIBRARY)
-    FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2main
-            REQUIRED_VARS SDL2MAIN_LIBRARY SDL2_INCLUDE_DIR
-            VERSION_VAR SDL2_VERSION_STRING)
-endif()
-
 
 mark_as_advanced(SDL2_PATH
         SDL2_NO_DEFAULT_PATH
@@ -383,6 +383,10 @@ if(SDL2_FOUND)
             set_property(TARGET SDL2::Main APPEND PROPERTY
                     INTERFACE_LINK_LIBRARIES SDL2::MainInternal)
         endif()
+        
+        # compatibility targets
+        add_library(SDL2::SDL2 ALIAS SDL2::Core)
+        add_library(SDL2::SDL2main ALIAS SDL2::Main)
 
     endif()
 endif()


### PR DESCRIPTION
Fixes the following warning as proposed [here](https://github.com/aminosbh/sdl2-cmake-modules/pull/6):

```
CMake Warning (dev) at /usr/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (SDL2main)
  does not match the name of the calling package (SDL2).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake_modules/FindSDL2.cmake:318 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:171 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```