### PR TITLE
Define the MACOS_X flag for macOS builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,6 +466,8 @@ ifeq ($(COMPILE_PLATFORM),darwin)
 
   BASE_CFLAGS += -Wno-unused-result
 
+  BASE_CFLAGS += -DMACOS_X
+
   OPTIMIZE = -O2 -fvisibility=hidden
 
   SHLIBEXT = dylib


### PR DESCRIPTION
This makes the game look for its files in the right place on macOS.
