### PR TITLE
custom entity overrides via mapname.ent files

### DIFF
--- a/code/server/server.h
+++ b/code/server/server.h
@@ -303,6 +303,8 @@ extern	cvar_t	*sv_lanForceRate;
 extern	cvar_t *sv_levelTimeReset;
 extern	cvar_t *sv_filter;
 
+extern cvar_t *sv_entityPath;
+
 #ifdef USE_BANS
 extern	cvar_t	*sv_banFile;
 extern	serverBan_t serverBans[SERVER_MAXBANS];

--- a/code/server/sv_game.c
+++ b/code/server/sv_game.c
@@ -1002,6 +1002,36 @@ void SV_ShutdownGameProgs( void ) {
 	FS_VM_CloseFiles( H_QAGAME );
 }
 
+/*
+==================
+SV_GetCustomEntityString
+Read custom entity string from entity file for current map if it exists
+Author: Wiz
+==================
+*/
+static char *SV_GetCustomEntityString(void)
+{
+    char filename[MAX_QPATH];
+    union {
+        char *c;
+        void *v;
+    } f;
+
+	if ( sv_entityPath->string[0] != '\0' )
+        Com_sprintf(filename, sizeof(filename), "%s%c%s.ent", sv_entityPath->string, PATH_SEP, sv_mapname->string);
+    else
+        Com_sprintf(filename, sizeof(filename), "%s.ent", sv_mapname->string);
+
+    FS_ReadFile(filename, &f.v);
+
+    if (!f.v)
+        return NULL;
+
+    FS_FreeFile(f.v);
+
+    return f.c;
+}
+
 
 /*
 ==================
@@ -1014,7 +1044,11 @@ static void SV_InitGameVM( qboolean restart ) {
 	int		i;
 
 	// start the entity parsing at the beginning
-	sv.entityParsePoint = CM_EntityString();
+	//sv.entityParsePoint = CM_EntityString();
+
+	// now we can replace all entities on the map with out own
+	if ( !( sv.entityParsePoint = SV_GetCustomEntityString() ) )
+		sv.entityParsePoint = CM_EntityString();
 
 	// clear all gentity pointers that might still be set from
 	// a previous level

--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -755,6 +755,8 @@ void SV_Init( void )
 	Cvar_SetDescription( sv_zombietime, "Seconds to sink messages after disconnect." );
 	Cvar_Get ("nextmap", "", CVAR_TEMP );
 
+	sv_entityPath = Cvar_Get("sv_entityPath", "maps", CVAR_ARCHIVE );
+
 	sv_allowDownload = Cvar_Get ("sv_allowDownload", "1", CVAR_SERVERINFO);
 	Cvar_SetDescription( sv_allowDownload, "Toggle the ability for clients to download files maps etc. from server." );
 	Cvar_Get ("sv_dlURL", "", CVAR_SERVERINFO | CVAR_ARCHIVE);

--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -57,6 +57,8 @@ cvar_t	*sv_lanForceRate; // dedicated 1 (LAN) server forces local client rates t
 cvar_t *sv_levelTimeReset;
 cvar_t *sv_filter;
 
+cvar_t *sv_entityPath;
+
 #ifdef USE_BANS
 cvar_t	*sv_banFile;
 serverBan_t serverBans[SERVER_MAXBANS];


### PR DESCRIPTION
Support for overriding map entities with a mapname.ent file in the maps folder.