### PR TITLE
Don't spawn loading clients during map restart

### DIFF
--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -351,13 +351,8 @@ static void SV_MapRestart_f( void ) {
 			continue;
 		}
 
-		if ( client->state == CS_ACTIVE )
+		if ( client->state == CS_ACTIVE ) {
 			SV_ClientEnterWorld( client, &client->lastUsercmd );
-		else {
-			// If we don't reset client->lastUsercmd and are restarting during map load,
-			// the client will hang because we'll use the last Usercmd from the previous map,
-			// which is wrong obviously.
-			SV_ClientEnterWorld( client, NULL );
 		}
 	}
 

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -2221,6 +2221,11 @@ void SV_ExecuteClientMessage( client_t *cl, msg_t *msg ) {
 		// TTimo - use a comparison here to catch multiple map_restart
 		if ( serverId - sv.restartedServerId >= 0 && serverId - sv.serverId < 0 ) {
 			// they just haven't caught the \map_restart yet
+			if ( cl->state < CS_ACTIVE ) {
+				// need to activate client, or serverid configstring won't be sent and we will
+				// be stuck in this check
+				SV_ClientEnterWorld( cl, NULL );
+			}
 			Com_DPrintf( "%s: ignoring pre map_restart / outdated client message\n", cl->name );
 			return;
 		}


### PR DESCRIPTION
This removes the call to SV_ClientEnterWorld during map restart for clients that haven't spawned yet. Fixes map failing to load if a map restart occurs during a UDP download (due to CS_ACTIVE check in SV_DoneDownload_f). Also prevents players from spawning prematurely if a map restart occurs while they are loading the map.

A download-specific fix would also be an option, but this method may be more correct, as there doesn't seem to be a reason to forcibly spawn players if a map restart happens to occur while they are loading the map. It appears that [cnq3](https://bitbucket.org/CPMADevs/cnq3/src/26bfe007c1b9c0da51944f469efd1427b7ece10d/code/server/sv_ccmds.cpp#lines-299) uses the same approach.