### PR TITLE
Don't change serverid during map restart

### DIFF
--- a/code/server/server.h
+++ b/code/server/server.h
@@ -67,7 +67,6 @@ typedef struct {
 	serverState_t	state;
 	qboolean		restarting;			// if true, send configstring changes during SS_LOADING
 	int				serverId;			// changes each server start
-	int				restartedServerId;	// serverId before a map_restart
 	int				checksumFeed;		// the feed key that we use to compute the pure checksum strings
 	// https://zerowing.idsoftware.com/bugzilla/show_bug.cgi?id=475
 	// the serverId associated with the current checksumFeed (always <= serverId)

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -2251,12 +2251,6 @@ void SV_ExecuteClientMessage( client_t *cl, msg_t *msg ) {
 	// but we still need to read the next message to move to next download or send gamestate
 	// I don't like this hack though, it must have been working fine at some point, suspecting the fix is somewhere else
 	if ( serverId != sv.serverId && !*cl->downloadName && !strstr(cl->lastClientCommandString, "nextdl") ) {
-		// TTimo - use a comparison here to catch multiple map_restart
-		if ( serverId - sv.restartedServerId >= 0 && serverId - sv.serverId < 0 ) {
-			// they just haven't caught the \map_restart yet
-			Com_DPrintf( "%s: ignoring pre map_restart / outdated client message\n", cl->name );
-			return;
-		}
 		// if we can tell that the client has dropped the last gamestate we sent them, resend it
 		if ( cl->state != CS_ACTIVE && cl->messageAcknowledge - cl->gamestateMessageNum > 0 ) {
 			if ( !SVC_RateLimit( &cl->gamestate_rate, 4, 1000 ) ) {

--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -511,7 +511,6 @@ void SV_SpawnServer( const char *mapname, qboolean killBots ) {
 
 	// serverid should be different each time
 	sv.serverId = com_frameTime;
-	sv.restartedServerId = sv.serverId; // I suppose the init here is just to be safe
 	sv.checksumFeedServerId = sv.serverId;
 	Cvar_Set( "sv_serverid", va( "%i", sv.serverId ) );
 


### PR DESCRIPTION
Since the SV_ClientEnterWorld call for loading clients was removed in ed4af16763684a9b492c4c6737833531b43963e2, clients will hang if a map restart occurs while they are loading the map.

This is because a new serverid is generated during the map restart, but the new serverid is not sent to the client because it is part of the systeminfo configstring, and configstring updates are deferred for loading (CS_PRIMED) clients until ClientEnterWorld is called. However ClientEnterWorld is never called through the normal route in SV_ExecuteClientMessage because it has checks that abort any actions for clients with an outdated serverid. As a result the client is stuck, not set to active, not receiving valid snapshots, and not receiving the updated serverid.

This change fixes this problem by removing the serverid modification during map restart. It also fixes a case where a map change AND map restart occur while a client is loading the previous map. Some extra checks are added to skip movement commands prior to the map restart, to emulate original behavior for mod compatibility purposes.

One compatibility concern with this fix is if a mod were to explicitly check the sv_serverid cvar and expect it to change after a map restart. However I think this is very unlikely.