### PR TITLE
Set client state to CS_CONNECTED during UDP downloads

### DIFF
--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -1377,6 +1377,9 @@ static int SV_WriteDownloadToClient( client_t *cl )
 		Com_Printf( "clientDownload: %d : beginning \"%s\"\n", (int) (cl - svs.clients), cl->downloadName );
 
 		// Init
+		SV_PrintClientStateChange( cl, CS_CONNECTED );
+		cl->state = CS_CONNECTED;
+
 		cl->downloadCurrentBlock = cl->downloadClientBlock = cl->downloadXmitBlock = 0;
 		cl->downloadCount = 0;
 		cl->downloadEOF = qfalse;


### PR DESCRIPTION
Currently the server leaves clients set to CS_PRIMED during UDP downloads. This means that reliable commands from server to client can be generated, but not sent while the download is in progress. This can lead to a surge of commands being sent when the download finishes, or if enough commands are generated, the client being dropped with a "server command overflow" error.

This fix sets the client to CS_CONNECTED during downloads, which prevents unnecessary commands from being issued until the download completes and the new gamestate is sent.

Downloading clients were already set to CS_CONNECTED if a map change occurred during the download, but with this change it is set for all downloads.