### PR TITLE
Use nanosleep(2) instead of usleep(3)

### DIFF
--- a/code/qcommon/net_ip.c
+++ b/code/qcommon/net_ip.c
@@ -1895,7 +1895,10 @@ qboolean NET_Sleep( int timeout )
 		Sleep( timeout / 1000 );
 		return qtrue;
 #else
-		usleep( timeout );
+		struct timespec req;
+		req.tv_sec = timeout / 1000000;
+		req.tv_nsec = ( timeout % 1000000 ) * 1000;
+		nanosleep( &req, NULL );
 		return qtrue;
 #endif
 	}

--- a/code/unix/linux_qgl.c
+++ b/code/unix/linux_qgl.c
@@ -74,7 +74,10 @@ void QGL_Shutdown( qboolean unloadDLL )
 		// huh?), and it defaults to 0. For me, 500 seems to work.
 		//if( r_GLlibCoolDownMsec->integer )
 		//	usleep( r_GLlibCoolDownMsec->integer * 1000 );
-		usleep( 250 * 1000 );
+		struct timespec req;
+		req.tv_sec = 0;
+		req.tv_nsec = 250 * 1000000;
+		nanosleep( &req, NULL );
 
 		dlclose( glw_state.OpenGLLib );
 

--- a/code/unix/linux_snd.c
+++ b/code/unix/linux_snd.c
@@ -729,10 +729,14 @@ static int xrun_recovery( snd_pcm_t *handle, int err )
 	else if ( err == -ESTRPIPE )
 	{
 		int tries = 0;
+		struct timespec req;
+		req.tv_sec = period_time / 1000000;
+		req.tv_nsec = ( period_time % 1000000 ) * 1000;
+
 		/* wait until the suspend flag is released */
 		while ( ( err = _snd_pcm_resume( handle ) ) == -EAGAIN )
 		{
-			usleep( period_time );
+			nanosleep( &req, NULL );
 			if ( tries++ < 16 )
 			{
 				break;

--- a/code/unix/unix_main.c
+++ b/code/unix/unix_main.c
@@ -637,7 +637,10 @@ void Sys_Sleep( int msec ) {
 		return;
 	}
 #if 1
-	usleep( msec * 1000 );
+	struct timespec req;
+	req.tv_sec = msec / 1000;
+	req.tv_nsec = ( msec % 1000 ) * 1000000;
+	nanosleep( &req, NULL );
 #else
 	if ( com_dedicated->integer && stdin_active ) {
 		FD_ZERO( &fdset );


### PR DESCRIPTION
usleep(3) was declared obsolete in POSIX.1-2001 and removed in POSIX.1-2008 and nanosleep(2) was recommended to be used instead.