### PR TITLE
Use SDL_WINDOW_FULLSCREEN_DESKTOP on macOS

### DIFF
--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -272,7 +272,11 @@ static int GLW_SetMode( int mode, const char *modeFS, qboolean fullscreen, qbool
 
 	if ( fullscreen )
 	{
+#ifdef MACOS_X
+		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+#else
 		flags |= SDL_WINDOW_FULLSCREEN;
+#endif
 	}
 	else if ( r_noborder->integer )
 	{


### PR DESCRIPTION
This makes Command+Tab work, so we can switch to other applications while Quake 3 is running.

It also makes it possible to show the game below the notch on Macbooks with a notch.