### PR TITLE
Increase default `cl_maxpackets` to 125

### DIFF
--- a/code/client/cl_input.c
+++ b/code/client/cl_input.c
@@ -978,7 +978,7 @@ void CL_InitInput( void ) {
 	cl_anglespeedkey = Cvar_Get( "cl_anglespeedkey", "1.5", 0 );
 	Cvar_SetDescription( cl_anglespeedkey, "Set the speed that the direction keys (not mouse) change the view angle." );
 
-	cl_maxpackets = Cvar_Get ("cl_maxpackets", "60", CVAR_ARCHIVE );
+	cl_maxpackets = Cvar_Get ("cl_maxpackets", "125", CVAR_ARCHIVE );
 	Cvar_CheckRange( cl_maxpackets, "15", "125", CV_INTEGER );
 	Cvar_SetDescription( cl_maxpackets, "Set how many client packets are sent to the server per second, can't exceed \\com_maxFPS." );
 	cl_packetdup = Cvar_Get( "cl_packetdup", "1", CVAR_ARCHIVE_ND );


### PR DESCRIPTION
This decreases latency if FPS is greater than or equal to 60 (since the previous default for `cl_maxpackets` was `60`), and allows for more consistent input handling. `com_maxfps` already defaults to 125, so it's a 1:1 match if your PC can render 125 FPS.

~~Increasing `snaps` further does not change anything on servers running `sv_fps 20` or `sv_fps 40`, but it ensures you automatically benefit from increased position update rates on servers running higher `sv_fps`. This in turn allows you to see players' positions more accurately compared to their real position on the server.~~
**Edit:** This PR no longer changes the default of `snaps`, see https://github.com/ec-/Quake3e/pull/299#issuecomment-2422973974.

I've been using this configuration for years now and it works just fine, even on an average ADSL connection (before I had fiber).