### PR TITLE
Implement r_teleporterFlash cvar

### DIFF
--- a/code/renderer/tr_backend.c
+++ b/code/renderer/tr_backend.c
@@ -454,7 +454,11 @@ static void RB_Hyperspace( void ) {
 
 	RB_SetGL2D();
 
-	c.rgba[0] = c.rgba[1] = c.rgba[2] = (backEnd.refdef.time & 255);
+	if (r_teleporterFlash->integer == 0) {
+		c.rgba[0] = c.rgba[1] = c.rgba[2] = (backEnd.refdef.time &   0); // fade to black
+	} else {
+		c.rgba[0] = c.rgba[1] = c.rgba[2] = (backEnd.refdef.time & 255); // fade to white
+	}
 	c.rgba[3] = 255;
 
 	RB_AddQuadStamp2( backEnd.refdef.x, backEnd.refdef.y, backEnd.refdef.width, backEnd.refdef.height,

--- a/code/renderer/tr_init.c
+++ b/code/renderer/tr_init.c
@@ -60,6 +60,8 @@ cvar_t	*r_greyscale;
 
 static cvar_t *r_ignorehwgamma;
 
+cvar_t  *r_teleporterFlash;
+
 cvar_t	*r_fastsky;
 cvar_t	*r_neatsky;
 cvar_t	*r_drawSun;
@@ -1548,6 +1550,8 @@ static void R_Register( void )
 	ri.Cvar_SetDescription( r_stereoSeparation, "Control eye separation. Resulting separation is \\r_zproj divided by this value in standard units." );
 	r_ignoreGLErrors = ri.Cvar_Get( "r_ignoreGLErrors", "1", CVAR_ARCHIVE_ND );
 	ri.Cvar_SetDescription( r_ignoreGLErrors, "Ignore OpenGL errors." );
+	r_teleporterFlash = ri.Cvar_Get( "r_teleporterFlash", "1", CVAR_ARCHIVE );
+	ri.Cvar_SetDescription( r_teleporterFlash, "Show a white screen instead of a black screen when being teleported in hyperspace." );
 	r_fastsky = ri.Cvar_Get( "r_fastsky", "0", CVAR_ARCHIVE_ND );
 	ri.Cvar_SetDescription( r_fastsky, "Draw flat colored skies." );
 	r_drawSun = ri.Cvar_Get( "r_drawSun", "0", CVAR_ARCHIVE_ND );

--- a/code/renderer/tr_local.h
+++ b/code/renderer/tr_local.h
@@ -1218,6 +1218,8 @@ extern cvar_t	*r_stereoSeparation;			// separation of cameras for stereo renderi
 extern cvar_t	*r_lodbias;				// push/pull LOD transitions
 extern cvar_t	*r_lodscale;
 
+extern cvar_t	*r_teleporterFlash;		// teleport hyperspace visual
+
 extern cvar_t	*r_fastsky;				// controls whether sky should be cleared or drawn
 extern cvar_t	*r_neatsky;				// nomip and nopicmip for skyboxes, cnq3 like look
 extern cvar_t	*r_drawSun;				// controls drawing of sun quad

--- a/code/renderer2/tr_backend.c
+++ b/code/renderer2/tr_backend.c
@@ -295,7 +295,11 @@ static void RB_Hyperspace( void ) {
 		// do initialization shit
 	}
 
-	c = ( backEnd.refdef.time & 255 ) / 255.0f;
+	if (r_teleporterFlash->integer == 0) {
+		c = ( backEnd.refdef.time &   0 ) / 255.0f; // fade to black
+	} else {
+		c = ( backEnd.refdef.time & 255 ) / 255.0f; // fade to white
+	}
 	qglClearColor( c, c, c, 1 );
 	qglClear( GL_COLOR_BUFFER_BIT );
 	qglClearColor(0.0f, 0.0f, 0.0f, 1.0f);

--- a/code/renderer2/tr_init.c
+++ b/code/renderer2/tr_init.c
@@ -60,6 +60,8 @@ cvar_t	*r_greyscale;
 cvar_t	*r_ignorehwgamma;
 cvar_t	*r_measureOverdraw;
 
+cvar_t  *r_teleporterFlash;
+
 cvar_t	*r_fastsky;
 cvar_t	*r_drawSun;
 cvar_t	*r_dynamiclight;
@@ -1270,6 +1272,8 @@ static void R_Register( void )
 	ri.Cvar_SetDescription( r_stereoSeparation, "Control eye separation. Resulting separation is \\r_zproj divided by this value in standard units." );
 	r_ignoreGLErrors = ri.Cvar_Get( "r_ignoreGLErrors", "1", CVAR_ARCHIVE );
 	ri.Cvar_SetDescription( r_ignoreGLErrors, "Ignore OpenGL errors." );
+	r_teleporterFlash = ri.Cvar_Get( "r_teleporterFlash", "1", CVAR_ARCHIVE );
+	ri.Cvar_SetDescription( r_teleporterFlash, "Show a white screen instead of a black screen when being teleported in hyperspace." );
 	r_fastsky = ri.Cvar_Get( "r_fastsky", "0", CVAR_ARCHIVE );
 	ri.Cvar_SetDescription( r_fastsky, "Draw flat colored skies." );
 	r_drawSun = ri.Cvar_Get( "r_drawSun", "0", CVAR_ARCHIVE );

--- a/code/renderer2/tr_local.h
+++ b/code/renderer2/tr_local.h
@@ -1686,6 +1686,8 @@ extern cvar_t	*r_measureOverdraw;		// enables stencil buffer overdraw measuremen
 extern cvar_t	*r_lodbias;				// push/pull LOD transitions
 extern cvar_t	*r_lodscale;
 
+extern cvar_t	*r_teleporterFlash;		// teleport hyperspace visual
+
 extern cvar_t	*r_fastsky;				// controls whether sky should be cleared or drawn
 extern cvar_t	*r_drawSun;				// controls drawing of sun quad
 extern cvar_t	*r_dynamiclight;		// dynamic lights enabled/disabled

--- a/code/renderervk/tr_backend.c
+++ b/code/renderervk/tr_backend.c
@@ -464,7 +464,11 @@ static void RB_Hyperspace( void ) {
 
 	RB_SetGL2D();
 
-	c.rgba[0] = c.rgba[1] = c.rgba[2] = (backEnd.refdef.time & 255);
+	if (r_teleporterFlash->integer == 0) {
+		c.rgba[0] = c.rgba[1] = c.rgba[2] = (backEnd.refdef.time &   0); // fade to black
+	} else {
+		c.rgba[0] = c.rgba[1] = c.rgba[2] = (backEnd.refdef.time & 255); // fade to white
+	}
 	c.rgba[3] = 255;
 
 	RB_AddQuadStamp2( backEnd.refdef.x, backEnd.refdef.y, backEnd.refdef.width, backEnd.refdef.height,

--- a/code/renderervk/tr_init.c
+++ b/code/renderervk/tr_init.c
@@ -65,6 +65,8 @@ cvar_t	*r_presentBits;
 
 static cvar_t *r_ignorehwgamma;
 
+cvar_t  *r_teleporterFlash;
+
 cvar_t	*r_fastsky;
 cvar_t	*r_neatsky;
 cvar_t	*r_drawSun;
@@ -1575,6 +1577,8 @@ static void R_Register( void )
 	ri.Cvar_SetDescription( r_stereoSeparation, "Control eye separation. Resulting separation is \\r_zproj divided by this value in standard units." );
 	r_ignoreGLErrors = ri.Cvar_Get( "r_ignoreGLErrors", "1", CVAR_ARCHIVE_ND );
 	ri.Cvar_SetDescription( r_ignoreGLErrors, "Ignore OpenGL errors." );
+	r_teleporterFlash = ri.Cvar_Get( "r_teleporterFlash", "1", CVAR_ARCHIVE );
+	ri.Cvar_SetDescription( r_teleporterFlash, "Show a white screen instead of a black screen when being teleported in hyperspace." );
 	r_fastsky = ri.Cvar_Get( "r_fastsky", "0", CVAR_ARCHIVE_ND );
 	ri.Cvar_SetDescription( r_fastsky, "Draw flat colored skies." );
 	r_drawSun = ri.Cvar_Get( "r_drawSun", "0", CVAR_ARCHIVE_ND );

--- a/code/renderervk/tr_local.h
+++ b/code/renderervk/tr_local.h
@@ -1303,6 +1303,8 @@ extern cvar_t	*r_stereoSeparation;			// separation of cameras for stereo renderi
 extern cvar_t	*r_lodbias;				// push/pull LOD transitions
 extern cvar_t	*r_lodscale;
 
+extern cvar_t	*r_teleporterFlash;		// teleport hyperspace visual
+
 extern cvar_t	*r_fastsky;				// controls whether sky should be cleared or drawn
 extern cvar_t	*r_neatsky;				// nomip and nopicmip for skyboxes, cnq3 like look
 extern cvar_t	*r_drawSun;				// controls drawing of sun quad


### PR DESCRIPTION
In Quake 3 Arena when the player goes in a teleporter entrance but has yet to arrive at the exit (probably due to the server and client architecture and ping) the renderer registers this as being in hyperspace and the screen is covered with a pure white shader. Having there brief pure white flashbangs is obviously bad for the more photosensitive players.

r_teleporerFlash is a new cvar which allows more photosensitive users to opt out of seeing a white flash every time they are in hyperspace between a teleporter entrance and its exit. For now there is only a fade to black option implemented alongside the fade to white original and default option.

The new feature is opt-in and preserves the original pure white teleporter flash as the default. Though I would be happy to change the cvar default to 0 to not flashbang users who explicitly do not wish for them.

Earlier this year CPMA developers [committed this](https://bitbucket.org/CPMADevs/cnq3/commits/c8e1eb546fc377c70072f263bfcd3f2f15bf6113) to cnq3 which allows players to draw pure black screens instead of white when in hyperspace.

Quake 3 DeFRaG has for a long time allowed for a shader which addresses the issue like this:

```
teleportEffect
{
    cull none
    {
        map gfx/colors/black.jpg
        blendFunc GL_zero GL_ONE
    }
}
```

Both of these will work in DeFRaG via quake3e or oDFe in the future (though when I attempted to test that shader with quake3e even before my changes I don't see it affecting the hyperspace visual but I guess it works for others) I have not looked at other engines or mods for what they are doing. I chose the same cvar name as cnq3 for cross-engine config compatibility and user intuitivity as I do not see a reason to change it.

This cvar is future-proof and extendable as more styles are easy to add with the cvar value being 2 or above. 0 for black, 1 for white, 2 and above for new funky variants.

These changes implement the cvar in renderer, renderer2 and renderervk. (renderer2 and renderervk are untested but should work with the same copypaste changes AFAIK. Just running `make` did not build them and I did not look into how to build them.)