### PR TITLE
enable directory completion for \exec command 

### DIFF
--- a/code/qcommon/cmd.c
+++ b/code/qcommon/cmd.c
@@ -1011,8 +1011,21 @@ Cmd_CompleteCfgName
 ==================
 */
 static void Cmd_CompleteCfgName( const char *args, int argNum ) {
-	if( argNum == 2 ) {
-		Field_CompleteFilename( "", "cfg", qfalse, FS_MATCH_ANY | FS_MATCH_STICK );
+	if (argNum == 2) {
+		char path[MAX_OSPATH] = "";
+		const char *arg = Cmd_Argv(1);
+
+		// Look for the last forward slash to determine the
+		// directory portion of the path for file completion.
+		char *lastSlash = strrchr(arg, '/');
+
+		if (lastSlash) {
+			int newLength = lastSlash - arg + 1;
+			strncpy(path, arg, newLength);
+			path[newLength] = '\0';
+		}
+
+		Field_CompleteFilename(path, "cfg", qfalse, FS_MATCH_ANY | FS_MATCH_STICK);
 	}
 }
 

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -4607,7 +4607,8 @@ static qboolean Field_Complete( void )
 
 	if( matchCount == 1 )
 	{
-		Field_AddSpace();
+		if(completionField->buffer[completionField->cursor - 1] != '/')
+			Field_AddSpace();
 		return qtrue;
 	}
 
@@ -4765,6 +4766,12 @@ void Field_CompleteCommand( const char *cmd, qboolean doCommands, qboolean doCva
 	}
 	else
 		completionString = Cmd_Argv( completionArgument - 1 );
+		char *lastSlash = strrchr(completionString, '/');
+		if (lastSlash) {
+			// If a slash is found, set the completion string to everything after the last slash
+			// This is done to ensure that the completion function works with the correct file or directory name
+			completionString = lastSlash + 1;
+		}
 
 #ifndef DEDICATED
 	// Unconditionally add a '\' to the start of the buffer

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -4765,6 +4765,7 @@ void Field_CompleteCommand( const char *cmd, qboolean doCommands, qboolean doCva
 		completionArgument++;
 	}
 	else
+	{
 		completionString = Cmd_Argv( completionArgument - 1 );
 		char *lastSlash = strrchr(completionString, '/');
 		if (lastSlash) {
@@ -4772,6 +4773,7 @@ void Field_CompleteCommand( const char *cmd, qboolean doCommands, qboolean doCva
 			// This is done to ensure that the completion function works with the correct file or directory name
 			completionString = lastSlash + 1;
 		}
+	}
 
 #ifndef DEDICATED
 	// Unconditionally add a '\' to the start of the buffer


### PR DESCRIPTION
enable directory completion to allow TAB-ing into subdirectories to find configs. 

```
]\exec c <TAB>
    capt.cfg
    cash.cfg
    cfg-maps/oxodm108a_b2.cfg
    cfg-viewcam/viewcam-ne_duel.cfg
    configs/
    cracky.cfg
    
]\exec co <TAB>
]\exec configs/

]\exec configs/ <TAB>
    cpma/
    osp/
    q3plus/

]\exec configs/o <TAB>
]\exec configs/osp/

]\exec configs/osp/ <TAB>
]\exec configs/osp/all.cfg

```
![output4](https://github.com/user-attachments/assets/73650c60-e609-4a8c-9664-d9cbfefe06e1)

