### PR TITLE
Print messages about missing sounds in developer mode only.

### DIFF
--- a/code/client/snd_codec.c
+++ b/code/client/snd_codec.c
@@ -112,7 +112,7 @@ static void *S_CodecGetSound( const char *filename, snd_info_t *info )
 		}
 	}
 
-	Com_Printf( S_COLOR_YELLOW "WARNING: Failed to %s sound %s!\n", info ? "load" : "open", filename );
+	Com_DPrintf( S_COLOR_YELLOW "WARNING: Failed to %s sound %s!\n", info ? "load" : "open", filename );
 
 	return NULL;
 }

--- a/code/client/snd_dma.c
+++ b/code/client/snd_dma.c
@@ -331,7 +331,7 @@ static sfxHandle_t S_Base_RegisterSound( const char *name, qboolean compressed )
 
 	if ( sfx->soundData ) {
 		if ( sfx->defaultSound ) {
-			Com_Printf( S_COLOR_YELLOW "WARNING: could not find %s - using default\n", sfx->soundName );
+			Com_DPrintf( S_COLOR_YELLOW "WARNING: could not find %s - using default\n", sfx->soundName );
 			return 0;
 		}
 		return sfx - s_knownSfx;
@@ -343,7 +343,7 @@ static sfxHandle_t S_Base_RegisterSound( const char *name, qboolean compressed )
 	S_memoryLoad( sfx );
 
 	if ( sfx->defaultSound ) {
-		Com_Printf( S_COLOR_YELLOW "WARNING: could not find %s - using default\n", sfx->soundName );
+		Com_DPrintf( S_COLOR_YELLOW "WARNING: could not find %s - using default\n", sfx->soundName );
 		return 0;
 	}
 


### PR DESCRIPTION
Some of default q3 models have missing sounds. It causes annoying warnings in console:
```
^3WARNING: Failed to load sound sound/player/crash/taunt.wav!
^3WARNING: could not find sound/player/crash/taunt.wav - using default
```
This patch makes these messages visible only in developer mode.