### PR TITLE
Server: don't allow active clients to start downloads

### DIFF
--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -1284,6 +1284,8 @@ SV_BeginDownload_f
 ==================
 */
 static void SV_BeginDownload_f( client_t *cl ) {
+	if ( cl->state == CS_ACTIVE )
+		return;
 
 	// Kill any existing download
 	SV_CloseDownload( cl );


### PR DESCRIPTION
Currently clients can trigger a respawn by calling "download" command followed by "donedl", which allows for exploits such as causing CTF flags to disappear in unpatched mods. This fixes the problem by adding a guard for CS_ACTIVE clients to "download" command similar to the one that already exists for "donedl". Since legitimately downloading clients should never be at CS_ACTIVE this should not affect normal functionality.