### PR TITLE
Server: Delta snapshot developer print fix

### DIFF
--- a/code/server/server.h
+++ b/code/server/server.h
@@ -191,7 +191,8 @@ typedef struct client_s {
 	qboolean		downloadEOF;		// We have sent the EOF block
 	int				downloadSendTime;	// time we last got an ack from the client
 
-	int				deltaMessage;		// frame last client usercmd message
+	qboolean		deltaActive;		// delta snapshots enabled
+	int				deltaMessage;		// message to create delta snapshot from
 	int				lastPacketTime;		// svs.time when packet was last received
 	int				lastConnectTime;	// svs.time when connection started
 	int				lastDisconnectTime;

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -1167,7 +1167,7 @@ void SV_ClientEnterWorld( client_t *client ) {
 	ent->s.number = clientNum;
 	client->gentity = ent;
 
-	client->deltaMessage = client->netchan.outgoingSequence - (PACKET_BACKUP + 1); // force delta reset
+	client->deltaActive = qfalse;
 	client->lastSnapshotTime = svs.time - 9999; // generate a snapshot immediately
 
 	// call the game begin function
@@ -2135,11 +2135,8 @@ static void SV_UserMove( client_t *cl, msg_t *msg, qboolean delta ) {
 	usercmd_t	cmds[MAX_PACKET_USERCMDS], *cmd;
 	const usercmd_t *oldcmd;
 
-	if ( delta ) {
-		cl->deltaMessage = cl->messageAcknowledge;
-	} else {
-		cl->deltaMessage = cl->netchan.outgoingSequence - ( PACKET_BACKUP + 1 ); // force delta reset
-	}
+	cl->deltaActive = delta;
+	cl->deltaMessage = cl->messageAcknowledge;
 
 	cmdCount = MSG_ReadByte( msg );
 
@@ -2194,7 +2191,7 @@ static void SV_UserMove( client_t *cl, msg_t *msg, qboolean delta ) {
 	}
 
 	if ( cl->state != CS_ACTIVE ) {
-		cl->deltaMessage = cl->netchan.outgoingSequence - ( PACKET_BACKUP + 1 ); // force delta reset
+		cl->deltaActive = qfalse;
 		return;
 	}
 

--- a/code/server/sv_snapshot.c
+++ b/code/server/sv_snapshot.c
@@ -129,17 +129,12 @@ static void SV_WriteSnapshotToClient( const client_t *client, msg_t *msg ) {
 	frame = &client->frames[ client->netchan.outgoingSequence & PACKET_MASK ];
 
 	// try to use a previous frame as the source for delta compressing the snapshot
-	if ( /* client->deltaMessage <= 0 || */ client->state != CS_ACTIVE ) {
-		// client is asking for a retransmit
+	if ( !client->deltaActive || client->state != CS_ACTIVE ) {
 		oldframe = NULL;
 		lastframe = 0;
 	} else if ( client->netchan.outgoingSequence - client->deltaMessage >= (PACKET_BACKUP - 3) ) {
 		// client hasn't gotten a good message through in a long time
-		if ( com_developer->integer ) {
-			if ( client->deltaMessage != client->netchan.outgoingSequence - ( PACKET_BACKUP + 1 ) ) {
-				Com_Printf( "%s: Delta request from out of date packet.\n", client->name );
-			}
-		}
+		Com_DPrintf( "%s: Delta request from out of date packet.\n", client->name );
 		oldframe = NULL;
 		lastframe = 0;
 	} else {


### PR DESCRIPTION
Since 3f92ee47f5521a559a59c86b1a0b9ae8a3bba9a1 client->deltaMessage is set to `client->netchan.outgoingSequence - (PACKET_BACKUP + 1)` as a way to disable delta snapshots. Developer warnings like "Delta request from out of date packet" are not printed when client->deltaMessage matches this exact expression, but as `client->netchan.outgoingSequence` is incremented, warning messages may be printed when they shouldn't be.

This fix restores the behavior that client->deltaMessage is set to -1 to disable delta snapshots, allowing developer prints to correctly distinguish between delta being disabled intentionally versus by PACKET_BACKUP limit.