### PR TITLE
Server: don't delta from pre-map restart messages

### DIFF
--- a/code/server/server.h
+++ b/code/server/server.h
@@ -192,6 +192,7 @@ typedef struct client_s {
 	int				downloadSendTime;	// time we last got an ack from the client
 
 	qboolean		deltaActive;		// delta snapshots enabled
+	int				deltaStart;			// don't delta from messages earlier than this
 	int				deltaMessage;		// message to create delta snapshot from
 	int				lastPacketTime;		// svs.time when packet was last received
 	int				lastConnectTime;	// svs.time when connection started

--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -326,6 +326,9 @@ static void SV_MapRestart_f( void ) {
 	for ( i = 0; i < sv.maxclients; i++ ) {
 		client = &svs.clients[i];
 
+		// don't delta from pre-restart messages
+		client->deltaStart = client->netchan.outgoingSequence;
+
 		// send the new gamestate to all connected clients
 		if ( client->state < CS_CONNECTED ) {
 			continue;

--- a/code/server/sv_snapshot.c
+++ b/code/server/sv_snapshot.c
@@ -129,7 +129,7 @@ static void SV_WriteSnapshotToClient( const client_t *client, msg_t *msg ) {
 	frame = &client->frames[ client->netchan.outgoingSequence & PACKET_MASK ];
 
 	// try to use a previous frame as the source for delta compressing the snapshot
-	if ( !client->deltaActive || client->state != CS_ACTIVE ) {
+	if ( !client->deltaActive || client->deltaMessage < client->deltaStart || client->state != CS_ACTIVE ) {
 		oldframe = NULL;
 		lastframe = 0;
 	} else if ( client->netchan.outgoingSequence - client->deltaMessage >= (PACKET_BACKUP - 3) ) {


### PR DESCRIPTION
During map restart, client->deltaActive is set to false for active clients via SV_ClientEnterWorld. This typically causes one non-delta snapshot to be sent, but as client moves come in, client->deltaActive is set back to true, and subsequent snapshots have delta enabled even though the source frame may be prior to the map restart.

This restores the behavior prior to 250179bac4f81cc10d70bf538b3185bb08d882ea where snapshots are non-delta until a post-restart frame is available, regardless of client commands. I don't expect this makes much difference in practice, but it is more consistent and perhaps a bit safer to stick to the original behavior in case of theoretical snapshot overflow issues.