### PR TITLE
NULL Pointer Dereference vulnerability in `CL_DeltaEntity`.

### DIFF
--- a/code/client/cl_parse.c
+++ b/code/client/cl_parse.c
@@ -69,6 +69,8 @@ static void CL_DeltaEntity( msg_t *msg, clSnapshot_t *frame, int newnum, const e
 	state = &cl.parseEntities[cl.parseEntitiesNum & (MAX_PARSE_ENTITIES-1)];
 
 	if ( unchanged ) {
+		if(!old)
+			return;
 		*state = *old;
 	} else {
 		MSG_ReadDeltaEntity( msg, old, state, newnum );


### PR DESCRIPTION
The NULL Dereference vulnerability happens in  `void CL_DeltaEntity()`, `client/cl_parse.c`
How the NULL Pointer Dereference happens:
1. When the function `CL_ParsePacketEntities` calls `CL_DeltaEntityand` passes `oldstate` to `old`, the value of `oldstateis` NULL.
2. `oldstateis` set to NULL at `oldstate = NULL;`
3. Dereference of NULL variable `old` in `*state = *old;`
```
static void CL_ParsePacketEntities( msg_t *msg, const clSnapshot_t *oldframe, clSnapshot_t *newframe ) {
    const entityState_t *oldstate;
    int newnum;
    int oldindex, oldnum;

    newframe->parseEntitiesNum = cl.parseEntitiesNum;
    newframe->numEntities = 0;

    // delta from the entities present in oldframe
    oldindex = 0;
=>  oldstate = NULL;
    ......

    while ( 1 ) {
        // read the entity index number
        ......
        while ( oldnum < newnum ) {
            // one or more entities from the old packet are unchanged
            ......
=>          CL_DeltaEntity( msg, newframe, oldnum, oldstate, qtrue );
            ......
        }
        ......
    }
    ......
}


static void CL_DeltaEntity( msg_t *msg, clSnapshot_t *frame, int newnum, 
                        const entityState_t *old, qboolean unchanged) 
{
    entityState_t   *state;

    // save the parsed entity state into the big circular buffer so
    // it can be used as the source for a later delta
    state = &cl.parseEntities[cl.parseEntitiesNum & (MAX_PARSE_ENTITIES-1)];
    if ( unchanged ) {
=>      *state = *old;
    } else {
        MSG_ReadDeltaEntity( msg, old, state, newnum );
    }
    ......
}
```