### PR TITLE
fix: crash when viewing scores after changing model in-game

### DIFF
--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -1591,7 +1591,9 @@ int FS_FOpenFileRead( const char *filename, fileHandle_t *file, qboolean uniqueF
 	// The searchpaths do guarantee that something will always
 	// be prepended, so we don't need to worry about "c:" or "//limbo"
 	if ( FS_CheckDirTraversal( filename ) ) {
-		*file = FS_INVALID_HANDLE;
+		if (file) {
+			*file = FS_INVALID_HANDLE;
+		}
 		return -1;
 	}
 


### PR DESCRIPTION
Crash occurred if you:
1. Load a map
2. Change model with `model sarge/..`
3. Open `+scores`