### PR TITLE
IN: sync modifier keys with SDL state

### DIFF
--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -63,13 +63,22 @@ GLimp_Shutdown
 */
 void GLimp_Shutdown( qboolean unloadDLL )
 {
+	const char* drv = SDL_GetCurrentVideoDriver();
+
 	IN_Shutdown();
 
-	SDL_DestroyWindow( SDL_window );
-	SDL_window = NULL;
+	if ( glw_state.isFullscreen ) {
+		if ( drv && strcmp( drv, "x11" ) == 0 ) {
+			SDL_WarpMouseGlobal( glw_state.desktop_width / 2, glw_state.desktop_height / 2 );
+		} else {
+			SDL_ShowCursor( SDL_TRUE );
+		}
+	}
 
-	if ( glw_state.isFullscreen )
-		SDL_WarpMouseGlobal( glw_state.desktop_width / 2, glw_state.desktop_height / 2 );
+	if ( SDL_window ) {
+		SDL_DestroyWindow( SDL_window );
+		SDL_window = NULL;
+	}
 
 	if ( unloadDLL )
 		SDL_QuitSubSystem( SDL_INIT_VIDEO );
@@ -776,13 +785,22 @@ VKimp_Shutdown
 */
 void VKimp_Shutdown( qboolean unloadDLL )
 {
+	const char* drv = SDL_GetCurrentVideoDriver();
+
 	IN_Shutdown();
 
-	SDL_DestroyWindow( SDL_window );
-	SDL_window = NULL;
+	if ( glw_state.isFullscreen ) {
+		if ( drv && strcmp( drv, "x11" ) == 0 ) {
+			SDL_WarpMouseGlobal( glw_state.desktop_width / 2, glw_state.desktop_height / 2 );
+		} else {
+			SDL_ShowCursor( SDL_TRUE );
+		}
+	}
 
-	if ( glw_state.isFullscreen )
-		SDL_WarpMouseGlobal( glw_state.desktop_width / 2, glw_state.desktop_height / 2 );
+	if ( SDL_window ) {
+		SDL_DestroyWindow( SDL_window );
+		SDL_window = NULL;
+	}
 
 	if ( unloadDLL )
 		SDL_QuitSubSystem( SDL_INIT_VIDEO );

--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -452,6 +452,8 @@ IN_DeactivateMouse
 */
 static void IN_DeactivateMouse( void )
 {
+	const char* drv = SDL_GetCurrentVideoDriver();
+
 	if ( !mouseAvailable )
 		return;
 
@@ -472,7 +474,9 @@ static void IN_DeactivateMouse( void )
 			if ( glw_state.isFullscreen )
 				SDL_ShowCursor( SDL_TRUE );
 
-			SDL_WarpMouseGlobal( glw_state.desktop_width / 2, glw_state.desktop_height / 2 );
+			if ( drv && strcmp( drv, "x11" ) == 0 ) {
+				SDL_WarpMouseGlobal( glw_state.desktop_width / 2, glw_state.desktop_height / 2 );
+			}
 		}
 
 		mouseActive = qfalse;


### PR DESCRIPTION
Previously, when switching keyboard layouts or pressing modifier keys (Ctrl, Shift, Alt), their state could get out of sync with the SDL, causing the game to think the modifier was still pressed when it wasn't.

This adds the IN_SyncModifiers() that is called after the input is updated to correctly reflect the current state of the SDL modifier in the engine.

And fixed https://github.com/ec-/Quake3e/issues/350