### PR TITLE
Add syscall overflow detection to prevent VM infinite loops

### DIFF
--- a/code/qcommon/vm.c
+++ b/code/qcommon/vm.c
@@ -1954,6 +1954,10 @@ intptr_t QDECL VM_Call( vm_t *vm, int nargs, int callnum, ... )
 #endif
 
 	++vm->callLevel;
+	// reset syscall counter for top-level calls to detect infinite loops
+	if ( vm->callLevel == 1 ) {
+		vm->syscallCount = 0;
+	}
 	// if we have a dll loaded, call it directly
 	if ( vm->entryPoint )
 	{

--- a/code/qcommon/vm_local.h
+++ b/code/qcommon/vm_local.h
@@ -212,6 +212,8 @@ struct vm_s {
 	int			breakFunction;		// increment breakCount on function entry to this
 	int			breakCount;
 
+	int			syscallCount;		// syscall counter for current VM_Call invocation
+
 	int32_t		*jumpTableTargets;
 	int32_t		numJumpTableTargets;
 

--- a/code/server/sv_game.c
+++ b/code/server/sv_game.c
@@ -365,6 +365,15 @@ The module is making a system call
 ====================
 */
 static intptr_t SV_GameSystemCalls( intptr_t *args ) {
+
+	// detect infinite loops in QVM code by counting syscalls per VM_Call invocation
+	// the stock id 1.32 qagame.qvm has a bug in ClientSpawn() where a do/while(1) loop
+	// retrying spawn point selection can loop forever if all spawn points have FL_NO_BOTS
+	// set, causing the server to hang at 100% CPU
+	if ( ++gvm->syscallCount > 1000000 ) {
+		Com_Error( ERR_DROP, "game VM syscall overflow - Loss of control in VM" );
+	}
+
 	switch( args[0] ) {
 	case G_PRINT:
 		Com_Printf( "%s", (const char*)VMA(1) );


### PR DESCRIPTION
## Summary

- Adds a per-`VM_Call()` syscall counter that detects infinite loops in QVM code, preventing the server from hanging at 100% CPU
- The counter resets at each top-level `VM_Call()` invocation and triggers `Com_Error(ERR_DROP, ...)` after 1,000,000 syscalls
- This is a general safety improvement consistent with existing `vm_rtChecks` infrastructure

## Motivation

The stock id Software 1.32 `qagame.qvm` (from `pak8.pk3`) has an infinite loop bug in `ClientSpawn()` that causes the server to hang when all spawn points would telefrag (reproducible with 8+ bots on small maps like `cpm30_b1`). ioquake3 fixed this in the game code ([commit f5d79ea](https://github.com/ioquake/ioq3/commit/f5d79ea066c1f742ff8c98dd5d9c484b9db122e3)), but since Quake3e is engine-only and ships no QVMs, the fix must be engine-side.

See #370 for full root cause analysis and test results.

## Changes

| File | Change |
|------|--------|
| `code/qcommon/vm_local.h` | Add `syscallCount` field to `vm_t` struct |
| `code/qcommon/vm.c` | Reset counter at start of top-level `VM_Call()` |
| `code/server/sv_game.c` | Increment counter and check threshold in `SV_GameSystemCalls()` |

## Testing

| Test | Result |
|------|--------|
| 7 bots on cpm30_b1 (below trigger) | All bots spawn and fight normally, no overflow |
| 8 bots on q3dm17 (large map) | All 8 bots active, no false positive |
| 8 bots on cpm30_b1 (triggers bug) | Overflow detected, server shuts down cleanly instead of hanging |

Fixes #370