### PR TITLE
Wire up max_routingcache cvar to routing cache eviction logic

### DIFF
--- a/code/botlib/be_aas_route.c
+++ b/code/botlib/be_aas_route.c
@@ -1243,7 +1243,7 @@ void AAS_InitRouting(void)
 #endif //ROUTING_DEBUG
 	//
 	routingcachesize = 0;
-	max_routingcachesize = 1024 * (int) LibVarValue("max_routingcache", "4096");
+	max_routingcachesize = 1024 * (int) LibVarValue("max_routingcache", "12288");
 	// read any routing cache if available
 	AAS_ReadRouteCache();
 } //end of the function AAS_InitRouting
@@ -1627,7 +1627,7 @@ static int AAS_AreaRouteToGoalArea(int areanum, vec3_t origin, int goalareanum, 
 	} //end if
 
 	// make sure the routing cache doesn't grow to large
-	while ( routingcachesize > 12 * 1024 * 1024 ) {
+	while ( routingcachesize > max_routingcachesize ) {
 		if ( !AAS_FreeOldestCache() ) {
 			break;
 		}

--- a/code/botlib/botlib.h
+++ b/code/botlib/botlib.h
@@ -485,7 +485,7 @@ name:						default:			module(s):			description:
 "rs_maxjumpfallheight"		"450"				be_aas_move.c
 
 "max_aaslinks"				"4096"				be_aas_sample.c		maximum links in the AAS
-"max_routingcache"			"4096"				be_aas_route.c		maximum routing cache size in KB
+"max_routingcache"			"12288"				be_aas_route.c		maximum routing cache size in KB
 "forceclustering"			"0"					be_aas_main.c		force recalculation of clusters
 "forcereachability"			"0"					be_aas_main.c		force recalculation of reachabilities
 "forcewrite"				"0"					be_aas_main.c		force writing of aas file


### PR DESCRIPTION
## Summary

- Wire up the existing but unused `max_routingcachesize` variable in the routing cache eviction loop, replacing the hardcoded `12 * 1024 * 1024` constant
- Update the `max_routingcache` cvar default from `"4096"` to `"12288"` (KB) to preserve the existing 12 MB behavior
- Update the documentation in `botlib.h` to reflect the new default

This allows server operators to tune the bot routing cache size via the `max_routingcache` cvar, which was previously documented but had no effect.

Fixes #369