### PR TITLE
Update regex filter for QCOMMON_SRCS to avoid PowerPC code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules)
 
 AUX_SOURCE_DIRECTORY(code/qcommon QCOMMON_SRCS)
 # exclude platform-dependent QVM bytecode compilers
-list(FILTER QCOMMON_SRCS EXCLUDE REGEX ".*vm_[alx].*.c")
+list(FILTER QCOMMON_SRCS EXCLUDE REGEX ".*vm_[alpx].*.c")
 # add platform-dependent QVM bytecode compilers
 IF(CMAKE_SYSTEM_PROCESSOR MATCHES AMD64|x86|i*86)
 	IF(CMAKE_SYSTEM_PROCESSOR MATCHES AMD64)


### PR DESCRIPTION
I tried to build the latest sources with MinGW, but I got this error at compile time:
```
[48/210] Building C object CMakeFiles/qcommon.dir/code/qcommon/vm_powerpc.c.obj
FAILED: [code=1] CMakeFiles/qcommon.dir/code/qcommon/vm_powerpc.c.obj
code/qcommon/vm_powerpc.c:30:10: fatal error: sys/mman.h: No such file or directory
   30 | #include <sys/mman.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```
However, this is a nonsense because I expected to build x86_64 (or i686 or Aarch64) on MinGW, but not PowerPC.
For debugging, I added this line into CMakeLists.txt:
```
message(STATUS "QCOMMON_SRCS=${QCOMMON_SRCS}")
```
and CMake printed this:

`-- QCOMMON_SRCS=code/qcommon/cm_load.c;code/qcommon/cm_patch.c;code/qcommon/cm_polylib.c;code/qcommon/cm_test.c;code/qcommon/cm_trace.c;code/qcommon/cmd.c;code/qcommon/common.c;code/qcommon/cvar.c;code/qcommon/files.c;code/qcommon/history.c;code/qcommon/huffman.c;code/qcommon/huffman_static.c;code/qcommon/keys.c;code/qcommon/md4.c;code/qcommon/md5.c;code/qcommon/msg.c;code/qcommon/net_chan.c;code/qcommon/net_ip.c;code/qcommon/puff.c;code/qcommon/q_math.c;code/qcommon/q_shared.c;code/qcommon/unzip.c;code/qcommon/vm.c;code/qcommon/vm_interpreted.c;code/qcommon/vm_powerpc.c;code/qcommon/vm_x86.c`

In my opinion, `code/qcommon/vm_powerpc.c` shouldn't be there actually.
It seems that a tiny fix is needed into this regex expession:

https://github.com/ec-/Quake3e/blob/7ca63d8774c4cf7bc74262aa0d16e3b40849a95f/CMakeLists.txt#L22

for excluding that source if it is not needed.
Attached patch fixes it.

