### PR TITLE
Ignore OP_UNDEF when JITing similar to interpreter and original quake3

### DIFF
--- a/code/qcommon/vm_aarch64.c
+++ b/code/qcommon/vm_aarch64.c
@@ -1681,9 +1681,6 @@ __recompile:
 		switch ( ci->op )
 		{
 			case OP_UNDEF:
-				emit( BRK( 0 ) );
-				break;
-
 			case OP_IGNORE:
 				ip += ci->value;
 				break;

--- a/code/qcommon/vm_armv7l.c
+++ b/code/qcommon/vm_armv7l.c
@@ -1296,9 +1296,6 @@ __recompile:
 		switch ( ci->op )
 		{
 			case OP_UNDEF:
-				emit(BKPT(1));
-				break;
-
 			case OP_IGNORE:
 				ip += ci->value;
 				break;

--- a/code/qcommon/vm_interpreted.c
+++ b/code/qcommon/vm_interpreted.c
@@ -210,7 +210,7 @@ nextInstruction2:
 		ci++;
 
 		switch ( opcode ) {
-
+		case OP_UNDEF:
 		case OP_IGNORE:
 			ci += v0;
 			goto nextInstruction2;

--- a/code/qcommon/vm_powerpc.c
+++ b/code/qcommon/vm_powerpc.c
@@ -1893,9 +1893,6 @@ __recompile:
 		switch ( ci->op )
 		{
 			case OP_UNDEF:
-				emit( PPC_TRAP() );
-				break;
-
 			case OP_IGNORE:
 				ip += ci->value;
 				break;

--- a/code/qcommon/vm_x86.c
+++ b/code/qcommon/vm_x86.c
@@ -2913,9 +2913,6 @@ __compile:
 		switch ( ci->op ) {
 
 			case OP_UNDEF:
-				emit_brk();			// int 3
-				break;
-
 			case OP_IGNORE:
 				ip += ci->value;
 				break;


### PR DESCRIPTION
Original quake3.exe treats `OP_UNDEF` as a NOP in interpreted (implicitly cause `DEBUG_VM` wasn't defined for the builds and so it falls through to the next iteration)[1]. Similarly, it's also a NOP in JIT as it has an explicit `case 0: break;`[2].

Why does any of this matter? After all, `OP_IGNORE` is a thing and q3e correctly handles it for interpreted and JIT...?

Well... other engines such as original quake 3/ioq3 don't for JIT and they fallthrough to Com_Error because they don't have a case for `OP_IGNORE`[3]. Normally, none of this should matter as lcc/q3asm aren't going to be using either of these instructions, however we are patching some QVMs and it'd be nice to have a context-free single instruction NOP that works on all engines and modes (ie. JIT and interpreted).

For that reason, I've put up this PR to align quake3e with other engines, but feel free to close this if you don't want to.

Note: AFAICS none of the other uses of `OP_UNDEF` as a default/sentinel for optimization reasons should matter, so they were just left as-is.

[1] https://github.com/id-Software/Quake-III-Arena/blob/dbe4ddb10315479fc00086f08e25d968b4b43c49/code/qcommon/vm_interpreted.c#L411-L414
[2] https://github.com/id-Software/Quake-III-Arena/blob/dbe4ddb10315479fc00086f08e25d968b4b43c49/code/qcommon/vm_x86.c#L442-L443
[3] https://github.com/id-Software/Quake-III-Arena/blob/dbe4ddb10315479fc00086f08e25d968b4b43c49/code/qcommon/vm_x86.c#L1047-L1048