### PR TITLE
refactor: `baselineUsed` type `byte` -> `qboolean`

### DIFF
--- a/code/client/cl_parse.c
+++ b/code/client/cl_parse.c
@@ -573,7 +573,7 @@ static void CL_ParseGamestate( msg_t *msg ) {
 
 			es = &cl.entityBaselines[ newnum ];
 			MSG_ReadDeltaEntity( msg, &nullstate, es, newnum );
-			cl.baselineUsed[ newnum ] = 1;
+ 			cl.baselineUsed[ newnum ] = qtrue;
 		} else {
 			Com_Error( ERR_DROP, "%s: bad command byte", __func__ );
 		}

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -141,7 +141,7 @@ typedef struct {
 
 	entityState_t	parseEntities[MAX_PARSE_ENTITIES];
 
-	byte			baselineUsed[MAX_GENTITIES];
+	qboolean		baselineUsed[MAX_GENTITIES];
 } clientActive_t;
 
 extern	clientActive_t		cl;

--- a/code/server/server.h
+++ b/code/server/server.h
@@ -89,7 +89,7 @@ typedef struct {
 	int				restartTime;
 	int				time;
 
-	byte			baselineUsed[ MAX_GENTITIES ];
+	qboolean		baselineUsed[ MAX_GENTITIES ];
 } server_t;
 
 typedef struct {

--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -231,7 +231,7 @@ static void SV_CreateBaseline( void ) {
 		// take current state as baseline
 		//
 		sv.svEntities[ entnum ].baseline = ent->s;
-		sv.baselineUsed[ entnum ] = 1;
+		sv.baselineUsed[ entnum ] = qtrue;
 	}
 }
 


### PR DESCRIPTION
`qboolean` is a more "narrow" type, makes it clear that e.g.
there is no difference between `1` and `255`.
