### PR TITLE
botlib: stale variable in AAS_ValidateAASData causes false "bad clusterareanum" errors (regression in d6f26c2)

### DIFF
--- a/code/botlib/be_aas_file.c
+++ b/code/botlib/be_aas_file.c
@@ -230,7 +230,7 @@ static const char *AAS_ValidateAASData(void)
 		} else {
 			if (v >= aasworld.numclusters)
 				return "areasettings: bad cluster";
-			if ((unsigned)aasworld.areasettings[i].clusterareanum >= (v ? aasworld.clusters[c].numareas : 1))
+			if ((unsigned)aasworld.areasettings[i].clusterareanum >= (v ? aasworld.clusters[v].numareas : 1))
 				return "areasettings: bad clusterareanum";
 		}
 	}


### PR DESCRIPTION


<img width="717" height="114" alt="image" src="https://github.com/user-attachments/assets/1123d22d-01b3-468a-9075-698ce84464a8" />
