### PR TITLE
improvement: bump CVAR desc limit from 256 to 8192

### DIFF
--- a/code/qcommon/cvar.c
+++ b/code/qcommon/cvar.c
@@ -1920,7 +1920,7 @@ void Cvar_SetDescription2( const char *var_name, const char* var_description )
 	if ( !var || !var_description )
 		return;
 
-	if ( strlen( var_description ) >= MAX_CVAR_VALUE_STRING )
+	if ( strlen( var_description ) >= MAXPRINTMSG )
 		return;
 
 	if ( var_description[0] != '\0' )


### PR DESCRIPTION
256 is quite short, and we bump our head against it already
in the baseq3a mod:
https://github.com/ec-/baseq3a/pull/84.

Note that this does not increase memory usage
if no CVAR description is longer than 256.

(side note: maybe it'd be better
if we didn't copy the string at all and just used the original pointer,
because CVAR descriptions are usually string literals
which don't ever change).
