### PR TITLE
FS: don't delete source file on failed rename

### DIFF
--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 Copyright (C) 1999-2005 Id Software, Inc.
+Copyright (C) 2026 WofWca
 
 This file is part of Quake III Arena source code.
 
@@ -644,6 +645,7 @@ static qboolean FS_CreatePath( const char *OSPath ) {
 }
 
 
+// Unused
 /*
 =================
 FS_CopyFile
@@ -1019,6 +1021,8 @@ FS_SV_Rename
 */
 void FS_SV_Rename( const char *from, const char *to ) {
 	const char			*from_ospath, *to_ospath;
+	FILE 				*f;
+	int					res;
 
 	if ( !fs_searchpaths ) {
 		Com_Error( ERR_FATAL, "Filesystem call made without initialization" );
@@ -1036,10 +1040,19 @@ void FS_SV_Rename( const char *from, const char *to ) {
 		Com_Printf( "FS_SV_Rename: %s --> %s\n", from_ospath, to_ospath );
 	}
 
-	if ( rename( from_ospath, to_ospath ) ) {
-		// Failed, try copying it and deleting the original
-		FS_CopyFile( from_ospath, to_ospath );
-		FS_Remove( from_ospath );
+	f = Sys_FOpen( from_ospath, "rb" );
+	if ( f ) {
+		fclose( f );
+		// Whether `rename` succeeds if destination already exists
+		// is implementation-dependent, so let's remove the file
+		// for consistency.
+		FS_Remove( to_ospath );
+	}
+
+	res = rename( from_ospath, to_ospath );
+
+	if ( res != 0 && fs_debug->integer ) {
+		Com_Printf( S_COLOR_YELLOW "FS_SV_Rename failed: %i\n", res );
 	}
 }
 
@@ -1052,6 +1065,7 @@ FS_Rename
 void FS_Rename( const char *from, const char *to ) {
 	const char *from_ospath, *to_ospath;
 	FILE *f;
+	int res;
 
 	if ( !fs_searchpaths ) {
 		Com_Error( ERR_FATAL, "Filesystem call made without initialization" );
@@ -1072,13 +1086,16 @@ void FS_Rename( const char *from, const char *to ) {
 	f = Sys_FOpen( from_ospath, "rb" );
 	if ( f ) {
 		fclose( f );
+		// Whether `rename` succeeds if destination already exists
+		// is implementation-dependent, so let's remove the file
+		// for consistency.
 		FS_Remove( to_ospath );
 	}
 
-	if ( rename( from_ospath, to_ospath ) ) {
-		// Failed, try copying it and deleting the original
-		FS_CopyFile( from_ospath, to_ospath );
-		FS_Remove( from_ospath );
+	res = rename( from_ospath, to_ospath );
+
+	if ( res != 0 && fs_debug->integer ) {
+		Com_Printf( S_COLOR_YELLOW "FS_Rename failed: %i\n", res );
 	}
 }
 


### PR DESCRIPTION
If `rename` fails, we move on to the fallback copy-then-delete.
However, the fallback doesn't check whether `FS_CopyFile` succeeded.
If it didn't then we'll still proceed to delete the source file,
which can cause data loss.

Plausible scenario: `stoprecord` trying to write
to an already existing file that we are unable to override.

This can hypothetically break something
because some code might rely on the `Rename` functions
always ensuring that the source file is gone.
But OTOH the code also relies on the fact that `rename`
doesn't just delete the source file.

Note that that the added `FS_Remove( to_ospath );`
doesn't really change behavior, because we either way
try to override the destination file.

Similar commmit in ioq3:
https://github.com/ioquake/ioq3/commit/956c9a262ab85e6048cb5dcaf45b00a48f95d3fb.
